### PR TITLE
chore: normalize project-config.json across environments

### DIFF
--- a/.github/project-config.json
+++ b/.github/project-config.json
@@ -2,10 +2,10 @@
   "project_node_id": "PVT_kwHOAOpJ284Bftcf",
   "status_field_id": "PVTSSF_lAHOAOpJ284BftcfzhZ-bEw",
   "options": {
-    "Backlog": "32c71717",
-    "Ready": "5dfb800c",
-    "In Progress": "5cef5228",
-    "In Review": "907e8a4e",
-    "Done": "b597a745"
-  }
+  "Backlog": "32c71717",
+  "Ready": "5dfb800c",
+  "In Progress": "5cef5228",
+  "In Review": "907e8a4e",
+  "Done": "b597a745"
+}
 }


### PR DESCRIPTION
## Summary

- Aligns `.github/project-config.json` on `dev` with `stg`/`main`, which diverged during the #21 conflict resolution.
- Whitespace only — `dev` had 4-space nesting inside `options`, `stg`/`main` kept `main`'s original 2-space. No value changes.
- Takes `main`'s **exact bytes** rather than applying a formatter, so the three environments end up byte-identical rather than merely equivalent.

## Why bother

Nothing is broken today; `jq` and `move-issue.sh` read both forms identically. But this file has already caused one merge conflict, and it is the single file whose corruption breaks *every* board-automation workflow — an empty version of it on `dev` is what made `issue-to-in-progress` fail in #20. Leaving `dev` permanently out of sync with the branches it promotes into is the condition that produced the conflict in the first place.

## Test plan

- [x] `cmp` against `origin/main:.github/project-config.json` — byte-identical
- [x] `jq` assertion that `project_node_id`, `status_field_id` and all five `options` values are non-empty
- [x] `move-issue.sh 22 "Backlog"` run against the normalized file — exit 0, all status options resolve (idempotent; #22 was already Backlog, so no board state changed)
- [ ] After merge and promotion: `git diff origin/dev origin/main` should report no differences

Closes #22