### PR TITLE
feat: split SimpleFIN access URL into base URL and basic-auth secret

### DIFF
--- a/src/lib/simplefin/url.test.ts
+++ b/src/lib/simplefin/url.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { bridgeDashboardUrl, splitAccessUrl } from './url';
+
+describe('splitAccessUrl', () => {
+  it('separates credentials from the base URL', () => {
+    const { baseUrl, basicAuthSecret } = splitAccessUrl(
+      'https://alice:s3cret@bridge.simplefin.org/simplefin',
+    );
+    expect(baseUrl).toBe('https://bridge.simplefin.org/simplefin');
+    expect(basicAuthSecret).toBe(btoa('alice:s3cret'));
+  });
+
+  it('strips a trailing slash so path joining is unambiguous', () => {
+    const { baseUrl } = splitAccessUrl('https://a:b@bridge.simplefin.org/simplefin/');
+    expect(baseUrl).toBe('https://bridge.simplefin.org/simplefin');
+  });
+
+  it('preserves percent-encoded credentials', () => {
+    const { basicAuthSecret } = splitAccessUrl(
+      'https://user%40x.com:p%3Ass@bridge.simplefin.org/simplefin',
+    );
+    expect(basicAuthSecret).toBe(btoa('user@x.com:p:ss'));
+  });
+
+  it('rejects a URL with no credentials', () => {
+    expect(() => splitAccessUrl('https://bridge.simplefin.org/simplefin')).toThrow(
+      /credentials/i,
+    );
+  });
+
+  it('rejects a non-https URL', () => {
+    expect(() => splitAccessUrl('http://a:b@bridge.simplefin.org/simplefin')).toThrow(
+      /https/i,
+    );
+  });
+});
+
+describe('bridgeDashboardUrl', () => {
+  it('reduces to scheme and host', () => {
+    expect(bridgeDashboardUrl('https://bridge.simplefin.org/simplefin')).toBe(
+      'https://bridge.simplefin.org',
+    );
+  });
+});

--- a/src/lib/simplefin/url.ts
+++ b/src/lib/simplefin/url.ts
@@ -1,0 +1,45 @@
+/**
+ * A SimpleFIN access URL embeds credentials: https://user:pass@host/path
+ *
+ * The brokered network API never accepts inline credentials — it resolves them
+ * host-side from the secret store via `NetworkAuth.secretKey`. So we split the
+ * URL once, at claim time: the credential-free base goes to `storage`, and the
+ * base64 `user:pass` (the exact form `NetworkAuth` with type 'basic' expects)
+ * goes to `secrets`.
+ */
+export interface SplitAccessUrl {
+  baseUrl: string;
+  basicAuthSecret: string;
+}
+
+export function splitAccessUrl(accessUrl: string): SplitAccessUrl {
+  const url = new URL(accessUrl.trim());
+
+  if (url.protocol !== 'https:') {
+    throw new Error('SimpleFIN access URL must use https');
+  }
+  if (!url.username) {
+    throw new Error('SimpleFIN access URL is missing credentials');
+  }
+
+  // URL getters keep credentials percent-encoded; the Bridge issues them
+  // encoded, and basic auth is defined over the decoded bytes.
+  const user = decodeURIComponent(url.username);
+  const pass = decodeURIComponent(url.password);
+
+  url.username = '';
+  url.password = '';
+
+  const baseUrl = url.toString().replace(/\/+$/, '');
+
+  return { baseUrl, basicAuthSecret: btoa(`${user}:${pass}`) };
+}
+
+/**
+ * The Bridge management dashboard. There is no documented per-connection deep
+ * link, so the general dashboard is the honest target for a "fix this" link.
+ */
+export function bridgeDashboardUrl(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  return `${url.protocol}//${url.host}`;
+}


### PR DESCRIPTION
Task 2 of `docs/superpowers/plans/2026-08-07-simplefin-addon-v1.md`.

Adds `src/lib/simplefin/url.ts`:

- `splitAccessUrl(accessUrl)` → `{ baseUrl, basicAuthSecret }`. The brokered network API never accepts inline credentials (it resolves them host-side via `NetworkAuth.secretKey`), so the access URL is split once at claim time: a credential-free, trailing-slash-free base URL destined for `storage`, and the base64 `user:pass` destined for `secrets`. Rejects non-https URLs and URLs carrying no credentials.
- `bridgeDashboardUrl(baseUrl)` → scheme + host, for a "fix this connection" link.

Credentials are percent-decoded before base64 encoding, since basic auth is defined over the decoded bytes.

## Verification

- `pnpm vitest run src/lib/simplefin/url.test.ts` — 6 passed
- `pnpm test` — 7 passed (full suite)
- `pnpm type-check` — clean
- Ran against a realistic Bridge-issued access URL with a percent-encoded password (`9f%2Fx8Qa%3D%3D`): decodes to `9f/x8Qa==`, base64 round-trips, and no credential fragment survives into `baseUrl`.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)