### PR TITLE
feat: parse SimpleFIN accounts response with structured bridge errors

### DIFF
--- a/src/lib/simplefin/parse.test.ts
+++ b/src/lib/simplefin/parse.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { parseAccountsResponse } from './parse';
+
+const payload = {
+  errors: [],
+  accounts: [
+    {
+      org: { name: 'Test Bank', domain: 'testbank.com' },
+      id: 'ACT-1',
+      name: 'Checking',
+      currency: 'USD',
+      balance: '1234.56',
+      'balance-date': 1754524800,
+      transactions: [
+        {
+          id: 'TXN-1',
+          posted: 1754438400,
+          amount: '-42.10',
+          description: 'COFFEE',
+          payee: 'Blue Bottle',
+          memo: null,
+        },
+        { id: 'TXN-2', posted: 1754524800, amount: '2000.00', description: 'SALARY', pending: true },
+      ],
+      holdings: [],
+    },
+  ],
+};
+
+describe('parseAccountsResponse', () => {
+  it('parses accounts and keeps money as strings', () => {
+    const { accounts } = parseAccountsResponse(payload);
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].balance).toBe('1234.56');
+    expect(typeof accounts[0].balance).toBe('string');
+    expect(accounts[0].orgName).toBe('Test Bank');
+    expect(accounts[0].balanceDate).toBe(1754524800);
+  });
+
+  it('preserves transaction sign and pending flag', () => {
+    const [account] = parseAccountsResponse(payload).accounts;
+    expect(account.transactions[0].amount).toBe('-42.10');
+    expect(account.transactions[0].pending).toBe(false);
+    expect(account.transactions[1].pending).toBe(true);
+  });
+
+  it('falls back to org domain when name is absent', () => {
+    const { accounts } = parseAccountsResponse({
+      accounts: [{ ...payload.accounts[0], org: { domain: 'testbank.com' } }],
+    });
+    expect(accounts[0].orgName).toBe('testbank.com');
+  });
+
+  it('prefers structured errlist over the deprecated flat errors array', () => {
+    const { errors } = parseAccountsResponse({
+      accounts: [],
+      errors: ['legacy message'],
+      errlist: [{ code: 'AUTH', msg: 'Reauthenticate Test Bank', conn_id: 'C1' }],
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe('AUTH');
+    expect(errors[0].key).toBe('AUTH:C1');
+  });
+
+  it('wraps a legacy flat errors array when errlist is absent', () => {
+    const { errors } = parseAccountsResponse({ accounts: [], errors: ['boom'] });
+    expect(errors[0].code).toBe('legacy');
+    expect(errors[0].msg).toBe('boom');
+    expect(errors[0].key).toBe('legacy:boom');
+  });
+
+  it('throws on a payload that is not an object', () => {
+    expect(() => parseAccountsResponse('nope')).toThrow(/payload/i);
+  });
+});

--- a/src/lib/simplefin/parse.ts
+++ b/src/lib/simplefin/parse.ts
@@ -1,0 +1,134 @@
+export interface SfTransaction {
+  id: string;
+  /** Epoch seconds, as the Bridge reports it. */
+  posted: number;
+  /** Signed decimal string; negative means money out. Never parsed to a number. */
+  amount: string;
+  description: string;
+  payee: string | null;
+  memo: string | null;
+  pending: boolean;
+}
+
+export interface SfHolding {
+  symbol: string;
+  shares: string | null;
+  currency: string | null;
+  costBasis: string | null;
+  purchasePrice: string | null;
+  marketValue: string | null;
+}
+
+export interface SfAccount {
+  id: string;
+  name: string;
+  currency: string;
+  balance: string;
+  /** Epoch seconds. */
+  balanceDate: number;
+  orgName: string;
+  transactions: SfTransaction[];
+  holdings: SfHolding[];
+}
+
+export interface SfBridgeError {
+  code: string;
+  msg: string;
+  connId: string | null;
+  accountId: string | null;
+  /**
+   * Stable identity for deduping the same institution failure across runs.
+   * conn_id/account_id are the durable handles when present; msg is the
+   * last-resort key for legacy entries that carry neither.
+   */
+  key: string;
+}
+
+function str(value: unknown, fallback = ''): string {
+  return value === null || value === undefined || value === '' ? fallback : String(value);
+}
+
+function optStr(value: unknown): string | null {
+  return value === null || value === undefined || value === '' ? null : String(value);
+}
+
+function parseTransaction(raw: Record<string, unknown>): SfTransaction {
+  return {
+    id: str(raw.id),
+    posted: Number(raw.posted),
+    amount: str(raw.amount),
+    description: str(raw.description),
+    payee: optStr(raw.payee),
+    memo: optStr(raw.memo),
+    pending: Boolean(raw.pending),
+  };
+}
+
+function parseHolding(raw: Record<string, unknown>): SfHolding {
+  return {
+    symbol: str(raw.symbol),
+    shares: optStr(raw.shares),
+    currency: optStr(raw.currency),
+    costBasis: optStr(raw.cost_basis),
+    purchasePrice: optStr(raw.purchase_price),
+    marketValue: optStr(raw.market_value),
+  };
+}
+
+function parseAccount(raw: Record<string, unknown>): SfAccount {
+  const org = (raw.org ?? {}) as Record<string, unknown>;
+  const transactions = Array.isArray(raw.transactions) ? raw.transactions : [];
+  const holdings = Array.isArray(raw.holdings) ? raw.holdings : [];
+
+  return {
+    id: str(raw.id),
+    name: str(raw.name),
+    currency: str(raw.currency),
+    balance: str(raw.balance),
+    balanceDate: Number(raw['balance-date']),
+    orgName: str(org.name) || str(org.domain),
+    transactions: transactions.map((t) => parseTransaction(t as Record<string, unknown>)),
+    holdings: holdings.map((h) => parseHolding(h as Record<string, unknown>)),
+  };
+}
+
+function parseErrors(payload: Record<string, unknown>): SfBridgeError[] {
+  const errlist = payload.errlist;
+
+  if (Array.isArray(errlist) && errlist.length > 0) {
+    return errlist.map((entry) => {
+      const e = entry as Record<string, unknown>;
+      const code = str(e.code);
+      const msg = str(e.msg);
+      const connId = optStr(e.conn_id);
+      const accountId = optStr(e.account_id);
+      return { code, msg, connId, accountId, key: `${code}:${connId ?? accountId ?? msg}` };
+    });
+  }
+
+  const legacy = Array.isArray(payload.errors) ? payload.errors : [];
+  return legacy.map((msg) => ({
+    code: 'legacy',
+    msg: String(msg),
+    connId: null,
+    accountId: null,
+    key: `legacy:${String(msg)}`,
+  }));
+}
+
+export function parseAccountsResponse(payload: unknown): {
+  accounts: SfAccount[];
+  errors: SfBridgeError[];
+} {
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('SimpleFIN returned a payload that is not an object');
+  }
+
+  const body = payload as Record<string, unknown>;
+  const rawAccounts = Array.isArray(body.accounts) ? body.accounts : [];
+
+  return {
+    accounts: rawAccounts.map((a) => parseAccount(a as Record<string, unknown>)),
+    errors: parseErrors(body),
+  };
+}


### PR DESCRIPTION
Task 3 of `docs/superpowers/plans/2026-08-07-simplefin-addon-v1.md`.

Adds `src/lib/simplefin/parse.ts` — `parseAccountsResponse(payload)` → `{ accounts, errors }`, mapping the Bridge JSON to typed `SfAccount` / `SfTransaction` / `SfHolding` / `SfBridgeError`.

- **Money stays a string** throughout (`balance`, `amount`, `cost_basis`, `market_value`); timestamps (`posted`, `balance-date`) stay epoch seconds. Parsing money to a float would introduce rounding error.
- Prefers the structured `errlist` over the deprecated flat `errors[]`, falling back to wrapping legacy string entries with code `legacy`.
- Each error carries a stable `key` for cross-run dedupe: `conn_id`, else `account_id`, else `msg`.
- Tolerates missing fields rather than throwing — only a non-object payload is fatal.

## Verification

- `pnpm vitest run src/lib/simplefin/parse.test.ts` — 6 passed
- `pnpm test` — 13 passed (full suite)
- `pnpm type-check` — clean
- Probed with a realistic brokerage payload: holdings map snake_case → camelCase correctly, an `errlist` entry carrying only `account_id` produces key `AUTH_FAILED:ACT-9` (exercising the fallback chain), and `balance` stays `string`.

## Note for Task 7

The plan's test payload has `holdings: []`, so holdings parsing has no coverage in this suite. My probe exercised it manually and it works, but one behavior is worth carrying forward: a holding with no `symbol` (e.g. a cash-reserve line) parses to `symbol: ''` rather than being rejected. Snapshot sync in Task 7 will need to decide what to do with symbol-less holdings. I left the parser as the plan specifies rather than inventing handling here.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)