### PR TITLE
feat: add brokered SimpleFIN client and setup-token claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,23 @@ Full design and rationale:
 
 ---
 
+## Troubleshooting
+
+**Claiming a setup token fails with a broker rejection.** A setup token is
+base64 of a claim URL, and the addon POSTs to whatever host that URL names.
+The network broker refuses any host not listed in `manifest.json` →
+`network.allowedHosts`, which declares `bridge.simplefin.org` and
+`beta-bridge.simplefin.org`. A token issued by a Bridge on some other host —
+a self-hosted or white-label deployment — is rejected by the broker before
+any request goes out. That is a manifest allowlist problem, not a code
+problem: add the host to `allowedHosts` and rebuild.
+
+**A setup token is refused with HTTP 403.** Setup tokens are single-use. If a
+claim was already made with that token (including a partially-failed
+attempt), generate a fresh one in the SimpleFIN Bridge dashboard.
+
+---
+
 ## Contributing
 
 Work is tracked in GitHub Issues and the project board. Branching, PR and

--- a/src/lib/simplefin/claim.test.ts
+++ b/src/lib/simplefin/claim.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createMockHost } from '../../test/mockHost';
+import { claimSetupToken } from './claim';
+
+const CLAIM_URL = 'https://bridge.simplefin.org/simplefin/claim/DEMO';
+const ACCESS_URL = 'https://alice:s3cret@bridge.simplefin.org/simplefin';
+
+describe('claimSetupToken', () => {
+  it('base64-decodes the token and POSTs to the claim URL', async () => {
+    const host = createMockHost();
+    host.respond(/\/claim\//, { body: ACCESS_URL });
+
+    const result = await claimSetupToken(host.api.network, btoa(CLAIM_URL));
+
+    expect(host.requests[0].url).toBe(CLAIM_URL);
+    expect(host.requests[0].method).toBe('POST');
+    expect(result).toBe(ACCESS_URL);
+  });
+
+  it('tolerates surrounding whitespace in the pasted token', async () => {
+    const host = createMockHost();
+    host.respond(/\/claim\//, { body: `  ${ACCESS_URL}\n` });
+
+    const result = await claimSetupToken(host.api.network, `\n ${btoa(CLAIM_URL)} \n`);
+    expect(result).toBe(ACCESS_URL);
+  });
+
+  it('rejects a token that is not valid base64', async () => {
+    const host = createMockHost();
+    await expect(claimSetupToken(host.api.network, '!!!not base64!!!')).rejects.toThrow(
+      /setup token/i,
+    );
+  });
+
+  it('reports that a token is single-use when the claim is refused', async () => {
+    const host = createMockHost();
+    host.respond(/\/claim\//, { status: 403, body: 'Forbidden' });
+
+    await expect(claimSetupToken(host.api.network, btoa(CLAIM_URL))).rejects.toThrow(
+      /already been used|HTTP 403/i,
+    );
+  });
+});

--- a/src/lib/simplefin/claim.ts
+++ b/src/lib/simplefin/claim.ts
@@ -1,0 +1,34 @@
+import type { NetworkAPI } from '@wealthfolio/addon-sdk';
+
+/**
+ * Exchange a one-time SimpleFIN setup token for a permanent access URL.
+ *
+ * The setup token is base64 of the claim URL. It is single-use: if this fails
+ * after the Bridge has consumed it, the user must generate a fresh token.
+ */
+export async function claimSetupToken(net: NetworkAPI, setupToken: string): Promise<string> {
+  let claimUrl: string;
+  try {
+    claimUrl = atob(setupToken.trim());
+  } catch {
+    throw new Error('That does not look like a SimpleFIN setup token (not valid base64)');
+  }
+
+  if (!claimUrl.startsWith('https://')) {
+    throw new Error('That does not look like a SimpleFIN setup token (no https claim URL)');
+  }
+
+  const response = await net.request({ url: claimUrl, method: 'POST', body: '' });
+
+  if (response.status === 403) {
+    throw new Error(
+      'The Bridge refused this setup token (HTTP 403). Setup tokens are single-use — ' +
+        'generate a fresh one in the SimpleFIN Bridge dashboard.',
+    );
+  }
+  if (response.status !== 200) {
+    throw new Error(`Claiming the setup token failed: HTTP ${response.status}`);
+  }
+
+  return response.body.trim();
+}

--- a/src/lib/simplefin/client.test.ts
+++ b/src/lib/simplefin/client.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { createMockHost } from '../../test/mockHost';
+import { AUTH_SECRET_KEY, fetchAccounts } from './client';
+
+const BASE = 'https://bridge.simplefin.org/simplefin';
+
+describe('fetchAccounts', () => {
+  it('sends a brokered basic-auth request referencing the secret by key', async () => {
+    const host = createMockHost();
+    host.respond(/\/accounts/, { body: JSON.stringify({ accounts: [], errors: [] }) });
+
+    await fetchAccounts(host.api.network, BASE, {});
+
+    const [req] = host.requests;
+    expect(req.method).toBe('GET');
+    expect(req.auth).toEqual({ type: 'basic', secretKey: AUTH_SECRET_KEY });
+    // The credential must never appear in the URL — the host injects it.
+    expect(req.url).not.toContain('@');
+  });
+
+  it('builds the documented query parameters', async () => {
+    const host = createMockHost();
+    host.respond(/\/accounts/, { body: JSON.stringify({ accounts: [], errors: [] }) });
+
+    await fetchAccounts(host.api.network, BASE, {
+      startDate: 1754438400,
+      endDate: 1754524800,
+      pending: true,
+      accountIds: ['A-1', 'A-2'],
+    });
+
+    const url = new URL(host.requests[0].url);
+    expect(url.pathname).toBe('/simplefin/accounts');
+    expect(url.searchParams.get('start-date')).toBe('1754438400');
+    expect(url.searchParams.get('end-date')).toBe('1754524800');
+    expect(url.searchParams.get('pending')).toBe('1');
+    expect(url.searchParams.getAll('account')).toEqual(['A-1', 'A-2']);
+  });
+
+  it('omits optional parameters that were not supplied', async () => {
+    const host = createMockHost();
+    host.respond(/\/accounts/, { body: JSON.stringify({ accounts: [], errors: [] }) });
+
+    await fetchAccounts(host.api.network, BASE, {});
+
+    const url = new URL(host.requests[0].url);
+    expect(url.searchParams.has('start-date')).toBe(false);
+    expect(url.searchParams.has('pending')).toBe(false);
+  });
+
+  it('returns bridge errors without throwing so other accounts still sync', async () => {
+    const host = createMockHost();
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        accounts: [],
+        errlist: [{ code: 'AUTH', msg: 'Reauthenticate Test Bank', conn_id: 'C1' }],
+      }),
+    });
+
+    const result = await fetchAccounts(host.api.network, BASE, {});
+    expect(result.errors).toHaveLength(1);
+    expect(result.accounts).toEqual([]);
+  });
+
+  it('throws on a non-200 status', async () => {
+    const host = createMockHost();
+    host.respond(/\/accounts/, { status: 403, body: 'Forbidden' });
+
+    await expect(fetchAccounts(host.api.network, BASE, {})).rejects.toThrow(/403/);
+  });
+
+  it('throws a clear error when the body is not JSON', async () => {
+    const host = createMockHost();
+    host.respond(/\/accounts/, { body: '<html>gateway error</html>' });
+
+    await expect(fetchAccounts(host.api.network, BASE, {})).rejects.toThrow(/JSON/i);
+  });
+});

--- a/src/lib/simplefin/client.ts
+++ b/src/lib/simplefin/client.ts
@@ -1,0 +1,63 @@
+import type { NetworkAPI } from '@wealthfolio/addon-sdk';
+import { KEY_PREFIX } from '../constants';
+import { parseAccountsResponse, type SfAccount, type SfBridgeError } from './parse';
+
+/** Secret key holding base64(user:pass); resolved host-side by the network broker. */
+export const AUTH_SECRET_KEY = `${KEY_PREFIX}.auth`;
+
+export interface FetchAccountsOptions {
+  /** Epoch seconds. */
+  startDate?: number;
+  /** Epoch seconds. */
+  endDate?: number;
+  pending?: boolean;
+  accountIds?: string[];
+  balancesOnly?: boolean;
+}
+
+export async function fetchAccounts(
+  net: NetworkAPI,
+  baseUrl: string,
+  options: FetchAccountsOptions,
+): Promise<{ accounts: SfAccount[]; errors: SfBridgeError[] }> {
+  const url = new URL(`${baseUrl}/accounts`);
+
+  if (options.startDate !== undefined) {
+    url.searchParams.set('start-date', String(options.startDate));
+  }
+  if (options.endDate !== undefined) {
+    url.searchParams.set('end-date', String(options.endDate));
+  }
+  if (options.pending) {
+    url.searchParams.set('pending', '1');
+  }
+  if (options.balancesOnly) {
+    url.searchParams.set('balances-only', '1');
+  }
+  for (const id of options.accountIds ?? []) {
+    url.searchParams.append('account', id);
+  }
+
+  const response = await net.request({
+    url: url.toString(),
+    method: 'GET',
+    auth: { type: 'basic', secretKey: AUTH_SECRET_KEY },
+  });
+
+  if (response.status !== 200) {
+    throw new Error(`SimpleFIN Bridge returned HTTP ${response.status}`);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(response.body);
+  } catch {
+    // Bridges behind a proxy return HTML on outage; surface that plainly
+    // rather than letting a SyntaxError bubble up unattributed.
+    throw new Error('SimpleFIN Bridge returned a body that is not valid JSON');
+  }
+
+  // Bridge errors are returned, not thrown: a failing institution must not
+  // prevent the healthy accounts in the same response from syncing.
+  return parseAccountsResponse(payload);
+}

--- a/src/lib/simplefin/parse.test.ts
+++ b/src/lib/simplefin/parse.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { parseAccountsResponse } from './parse';
+
+const payload = {
+  errors: [],
+  accounts: [
+    {
+      org: { name: 'Test Bank', domain: 'testbank.com' },
+      id: 'ACT-1',
+      name: 'Checking',
+      currency: 'USD',
+      balance: '1234.56',
+      'balance-date': 1754524800,
+      transactions: [
+        {
+          id: 'TXN-1',
+          posted: 1754438400,
+          amount: '-42.10',
+          description: 'COFFEE',
+          payee: 'Blue Bottle',
+          memo: null,
+        },
+        { id: 'TXN-2', posted: 1754524800, amount: '2000.00', description: 'SALARY', pending: true },
+      ],
+      holdings: [],
+    },
+  ],
+};
+
+describe('parseAccountsResponse', () => {
+  it('parses accounts and keeps money as strings', () => {
+    const { accounts } = parseAccountsResponse(payload);
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0].balance).toBe('1234.56');
+    expect(typeof accounts[0].balance).toBe('string');
+    expect(accounts[0].orgName).toBe('Test Bank');
+    expect(accounts[0].balanceDate).toBe(1754524800);
+  });
+
+  it('preserves transaction sign and pending flag', () => {
+    const [account] = parseAccountsResponse(payload).accounts;
+    expect(account.transactions[0].amount).toBe('-42.10');
+    expect(account.transactions[0].pending).toBe(false);
+    expect(account.transactions[1].pending).toBe(true);
+  });
+
+  it('falls back to org domain when name is absent', () => {
+    const { accounts } = parseAccountsResponse({
+      accounts: [{ ...payload.accounts[0], org: { domain: 'testbank.com' } }],
+    });
+    expect(accounts[0].orgName).toBe('testbank.com');
+  });
+
+  it('prefers structured errlist over the deprecated flat errors array', () => {
+    const { errors } = parseAccountsResponse({
+      accounts: [],
+      errors: ['legacy message'],
+      errlist: [{ code: 'AUTH', msg: 'Reauthenticate Test Bank', conn_id: 'C1' }],
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe('AUTH');
+    expect(errors[0].key).toBe('AUTH:C1');
+  });
+
+  it('wraps a legacy flat errors array when errlist is absent', () => {
+    const { errors } = parseAccountsResponse({ accounts: [], errors: ['boom'] });
+    expect(errors[0].code).toBe('legacy');
+    expect(errors[0].msg).toBe('boom');
+    expect(errors[0].key).toBe('legacy:boom');
+  });
+
+  it('throws on a payload that is not an object', () => {
+    expect(() => parseAccountsResponse('nope')).toThrow(/payload/i);
+  });
+});

--- a/src/lib/simplefin/parse.ts
+++ b/src/lib/simplefin/parse.ts
@@ -1,0 +1,134 @@
+export interface SfTransaction {
+  id: string;
+  /** Epoch seconds, as the Bridge reports it. */
+  posted: number;
+  /** Signed decimal string; negative means money out. Never parsed to a number. */
+  amount: string;
+  description: string;
+  payee: string | null;
+  memo: string | null;
+  pending: boolean;
+}
+
+export interface SfHolding {
+  symbol: string;
+  shares: string | null;
+  currency: string | null;
+  costBasis: string | null;
+  purchasePrice: string | null;
+  marketValue: string | null;
+}
+
+export interface SfAccount {
+  id: string;
+  name: string;
+  currency: string;
+  balance: string;
+  /** Epoch seconds. */
+  balanceDate: number;
+  orgName: string;
+  transactions: SfTransaction[];
+  holdings: SfHolding[];
+}
+
+export interface SfBridgeError {
+  code: string;
+  msg: string;
+  connId: string | null;
+  accountId: string | null;
+  /**
+   * Stable identity for deduping the same institution failure across runs.
+   * conn_id/account_id are the durable handles when present; msg is the
+   * last-resort key for legacy entries that carry neither.
+   */
+  key: string;
+}
+
+function str(value: unknown, fallback = ''): string {
+  return value === null || value === undefined || value === '' ? fallback : String(value);
+}
+
+function optStr(value: unknown): string | null {
+  return value === null || value === undefined || value === '' ? null : String(value);
+}
+
+function parseTransaction(raw: Record<string, unknown>): SfTransaction {
+  return {
+    id: str(raw.id),
+    posted: Number(raw.posted),
+    amount: str(raw.amount),
+    description: str(raw.description),
+    payee: optStr(raw.payee),
+    memo: optStr(raw.memo),
+    pending: Boolean(raw.pending),
+  };
+}
+
+function parseHolding(raw: Record<string, unknown>): SfHolding {
+  return {
+    symbol: str(raw.symbol),
+    shares: optStr(raw.shares),
+    currency: optStr(raw.currency),
+    costBasis: optStr(raw.cost_basis),
+    purchasePrice: optStr(raw.purchase_price),
+    marketValue: optStr(raw.market_value),
+  };
+}
+
+function parseAccount(raw: Record<string, unknown>): SfAccount {
+  const org = (raw.org ?? {}) as Record<string, unknown>;
+  const transactions = Array.isArray(raw.transactions) ? raw.transactions : [];
+  const holdings = Array.isArray(raw.holdings) ? raw.holdings : [];
+
+  return {
+    id: str(raw.id),
+    name: str(raw.name),
+    currency: str(raw.currency),
+    balance: str(raw.balance),
+    balanceDate: Number(raw['balance-date']),
+    orgName: str(org.name) || str(org.domain),
+    transactions: transactions.map((t) => parseTransaction(t as Record<string, unknown>)),
+    holdings: holdings.map((h) => parseHolding(h as Record<string, unknown>)),
+  };
+}
+
+function parseErrors(payload: Record<string, unknown>): SfBridgeError[] {
+  const errlist = payload.errlist;
+
+  if (Array.isArray(errlist) && errlist.length > 0) {
+    return errlist.map((entry) => {
+      const e = entry as Record<string, unknown>;
+      const code = str(e.code);
+      const msg = str(e.msg);
+      const connId = optStr(e.conn_id);
+      const accountId = optStr(e.account_id);
+      return { code, msg, connId, accountId, key: `${code}:${connId ?? accountId ?? msg}` };
+    });
+  }
+
+  const legacy = Array.isArray(payload.errors) ? payload.errors : [];
+  return legacy.map((msg) => ({
+    code: 'legacy',
+    msg: String(msg),
+    connId: null,
+    accountId: null,
+    key: `legacy:${String(msg)}`,
+  }));
+}
+
+export function parseAccountsResponse(payload: unknown): {
+  accounts: SfAccount[];
+  errors: SfBridgeError[];
+} {
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('SimpleFIN returned a payload that is not an object');
+  }
+
+  const body = payload as Record<string, unknown>;
+  const rawAccounts = Array.isArray(body.accounts) ? body.accounts : [];
+
+  return {
+    accounts: rawAccounts.map((a) => parseAccount(a as Record<string, unknown>)),
+    errors: parseErrors(body),
+  };
+}

--- a/src/test/mockHost.ts
+++ b/src/test/mockHost.ts
@@ -1,0 +1,52 @@
+import { vi } from 'vitest';
+import type { HostAPI, NetworkRequest, NetworkResponse } from '@wealthfolio/addon-sdk';
+
+export interface MockHost {
+  api: HostAPI;
+  /** In-memory stand-ins for the host-side stores, assertable in tests. */
+  storage: Map<string, string>;
+  secrets: Map<string, string>;
+  /** Queue a response for the next network.request matching `urlPattern`. */
+  respond(urlPattern: RegExp, response: Partial<NetworkResponse>): void;
+  requests: NetworkRequest[];
+}
+
+export function createMockHost(): MockHost {
+  const storage = new Map<string, string>();
+  const secrets = new Map<string, string>();
+  const requests: NetworkRequest[] = [];
+  const routes: Array<{ pattern: RegExp; response: Partial<NetworkResponse> }> = [];
+
+  const api = {
+    storage: {
+      get: vi.fn(async (k: string) => storage.get(k) ?? null),
+      set: vi.fn(async (k: string, v: string) => void storage.set(k, v)),
+      delete: vi.fn(async (k: string) => void storage.delete(k)),
+    },
+    secrets: {
+      get: vi.fn(async (k: string) => secrets.get(k) ?? null),
+      set: vi.fn(async (k: string, v: string) => void secrets.set(k, v)),
+      delete: vi.fn(async (k: string) => void secrets.delete(k)),
+    },
+    network: {
+      request: vi.fn(async (req: NetworkRequest): Promise<NetworkResponse> => {
+        requests.push(req);
+        const match = routes.find((r) => r.pattern.test(req.url));
+        if (!match) throw new Error(`no mock route for ${req.url}`);
+        return { status: 200, headers: {}, body: '', ...match.response };
+      }),
+    },
+    accounts: { getAll: vi.fn(async () => []), create: vi.fn() },
+    activities: { checkImport: vi.fn(), import: vi.fn() },
+    snapshots: { checkImport: vi.fn(), importSnapshots: vi.fn() },
+    logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn(), trace: vi.fn() },
+  } as unknown as HostAPI;
+
+  return {
+    api,
+    storage,
+    secrets,
+    requests,
+    respond: (pattern, response) => void routes.push({ pattern, response }),
+  };
+}


### PR DESCRIPTION
Task 4 of `docs/superpowers/plans/2026-08-07-simplefin-addon-v1.md`.

> **Stacked on #34** (Task 3) — `client.ts` imports `parseAccountsResponse`. The diff shows Task 3's commit until #34 merges into `dev`; merge #34 first and this reduces to the Task 4 commit alone.

- `fetchAccounts(net, baseUrl, opts)` — brokered `GET {base}/accounts` with `auth: { type: 'basic', secretKey }`. The credential is referenced **by key** and resolved host-side, so it never appears in a URL the addon composes. Builds the documented query params (`start-date`, `end-date`, `pending`, `balances-only`, repeated `account`), omitting any not supplied.
- Bridge errors are **returned, not thrown** — a failing institution must not stop healthy accounts in the same response from syncing. Non-200 and non-JSON bodies do throw, with attributed messages (proxied Bridges return HTML on outage).
- `claimSetupToken(net, token)` — base64-decodes the token to its claim URL and POSTs. A 403 is reported as token reuse, since setup tokens are single-use, rather than as a generic failure.
- `src/test/mockHost.ts` — the shared `HostAPI` test double (in-memory storage/secrets, pattern-matched network routes, recorded requests) that Tasks 5–10 build on.

## Verification

- `pnpm vitest run src/lib/simplefin/client.test.ts` — 6 passed
- `pnpm vitest run src/lib/simplefin/claim.test.ts` — 4 passed
- `pnpm test` — 23 passed (full suite); `pnpm type-check` — clean
- **End-to-end probe** across Tasks 2–4 (claim → `splitAccessUrl` → `fetchAccounts`): the fetch URL is `.../simplefin/accounts?start-date=...` with no credential fragment, `auth` is `{type:'basic',secretKey:'simplefin.auth'}`, that key resolves to exactly the secret `splitAccessUrl` produced (decoding back to the original `user:pass`), and the response parses to 1 account. This is the first check that Tasks 2, 3 and 4 actually compose.

## Step 10 — allowlist

Verified programmatically rather than by eye: the claim URL host is matched against `manifest.json` → `network.allowedHosts` (`bridge.simplefin.org`, `beta-bridge.simplefin.org`) in the probe above. Documented in README under a new **Troubleshooting** section — a token from a self-hosted or white-label Bridge on another host is refused by the broker before any request leaves, which is a manifest problem, not a code one.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)