### PR TITLE
chore: gitignore .claude/chat-exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ credentials.json
 # reproducible; the fetched content itself is not, same as node_modules.
 .agents/
 .claude/skills/
+
+# Local agent session transcripts — not project source, not reproducible.
+.claude/chat-exports/


### PR DESCRIPTION
`.claude/chat-exports/` holds local Claude Code session transcripts. They are not project source and not reproducible state, but showed up as untracked files on every branch because `.gitignore` only covered `.claude/skills/`.

Adds an ignore rule alongside the existing vendored-skills rule.

Verified: `git check-ignore` confirms the four existing transcripts are now ignored, and `.gitignore` is the only file changed.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)