### PR TITLE
feat: add storage layer with bounded watermark, config and history

### DIFF
--- a/src/lib/storage/config.test.ts
+++ b/src/lib/storage/config.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createMockHost } from '../../test/mockHost';
+import { readConfig, writeConfig } from './config';
+
+describe('config', () => {
+  it('returns an empty config when nothing is stored', async () => {
+    const host = createMockHost();
+    expect(await readConfig(host.api)).toEqual({ baseUrl: null, mappings: [] });
+  });
+
+  it('round-trips a config', async () => {
+    const host = createMockHost();
+    const config = {
+      baseUrl: 'https://bridge.simplefin.org/simplefin',
+      mappings: [
+        {
+          sfAccountId: 'ACT-1',
+          wfAccountId: 'WF-1',
+          mode: 'CASH' as const,
+          sfAccountName: 'Checking',
+          orgName: 'Test Bank',
+        },
+      ],
+    };
+    await writeConfig(host.api, config);
+    expect(await readConfig(host.api)).toEqual(config);
+  });
+
+  it('never stores credentials in the base URL', async () => {
+    const host = createMockHost();
+    await writeConfig(host.api, {
+      baseUrl: 'https://bridge.simplefin.org/simplefin',
+      mappings: [],
+    });
+    const stored = [...host.storage.values()].join('');
+    expect(stored).not.toContain('@');
+  });
+
+  it('recovers from a corrupt config rather than throwing', async () => {
+    const host = createMockHost();
+    await host.api.storage.set('simplefin.config', '{not json');
+    expect(await readConfig(host.api)).toEqual({ baseUrl: null, mappings: [] });
+    expect(host.api.logger.error).toHaveBeenCalled();
+  });
+});

--- a/src/lib/storage/config.ts
+++ b/src/lib/storage/config.ts
@@ -1,0 +1,44 @@
+import type { HostAPI } from '@wealthfolio/addon-sdk';
+import { storageKey } from './keys';
+
+/** How a mapped SimpleFIN account is pushed into Wealthfolio. */
+export type SyncMode = 'CASH' | 'HOLDINGS';
+
+export interface AccountMapping {
+  sfAccountId: string;
+  wfAccountId: string;
+  mode: SyncMode;
+  /** Cached for display when the Bridge is unreachable. */
+  sfAccountName: string;
+  orgName: string;
+}
+
+export interface SyncConfig {
+  /** Credential-free SimpleFIN base URL. Credentials live in `secrets`. */
+  baseUrl: string | null;
+  mappings: AccountMapping[];
+}
+
+const CONFIG_KEY = storageKey('config');
+
+export function emptyConfig(): SyncConfig {
+  return { baseUrl: null, mappings: [] };
+}
+
+export async function readConfig(api: HostAPI): Promise<SyncConfig> {
+  const raw = await api.storage.get(CONFIG_KEY);
+  if (!raw) return emptyConfig();
+
+  try {
+    return JSON.parse(raw) as SyncConfig;
+  } catch (error) {
+    // Returning empty sends the user back to setup, which is recoverable;
+    // throwing here would leave the addon permanently unopenable.
+    api.logger.error(`[simplefin] corrupt config, falling back to empty: ${String(error)}`);
+    return emptyConfig();
+  }
+}
+
+export async function writeConfig(api: HostAPI, config: SyncConfig): Promise<void> {
+  await api.storage.set(CONFIG_KEY, JSON.stringify(config));
+}

--- a/src/lib/storage/history.test.ts
+++ b/src/lib/storage/history.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { createMockHost } from '../../test/mockHost';
+import { appendRun, HISTORY_LIMIT, readHistory } from './history';
+
+const run = (startedAt: string) => ({
+  startedAt,
+  finishedAt: startedAt,
+  accounts: [],
+  bridgeErrors: [],
+});
+
+describe('history', () => {
+  it('returns an empty list when nothing is stored', async () => {
+    const host = createMockHost();
+    expect(await readHistory(host.api)).toEqual([]);
+  });
+
+  it('stores newest first', async () => {
+    const host = createMockHost();
+    await appendRun(host.api, run('2026-08-01T00:00:00Z'));
+    await appendRun(host.api, run('2026-08-02T00:00:00Z'));
+    const history = await readHistory(host.api);
+    expect(history[0].startedAt).toBe('2026-08-02T00:00:00Z');
+  });
+
+  it('bounds the history so the value stays under the host size cap', async () => {
+    const host = createMockHost();
+    for (let i = 0; i < HISTORY_LIMIT + 5; i += 1) {
+      await appendRun(host.api, run(`2026-08-01T00:00:${String(i).padStart(2, '0')}Z`));
+    }
+    expect(await readHistory(host.api)).toHaveLength(HISTORY_LIMIT);
+  });
+});

--- a/src/lib/storage/history.ts
+++ b/src/lib/storage/history.ts
@@ -1,0 +1,53 @@
+import type { HostAPI } from '@wealthfolio/addon-sdk';
+import type { SfBridgeError } from '../simplefin/parse';
+import { storageKey } from './keys';
+
+export interface AccountRunResult {
+  sfAccountId: string;
+  sfAccountName: string;
+  orgName: string;
+  wfAccountId: string;
+  mode: 'CASH' | 'HOLDINGS';
+  /** null when the account failed before anything was counted. */
+  imported: number | null;
+  skipped: number | null;
+  duplicates: number | null;
+  /** Populated only when this account failed; other accounts are unaffected. */
+  error: string | null;
+  /** Set when SimpleFIN and Wealthfolio balances disagree after the run. */
+  balanceMismatch: { simplefin: string; wealthfolio: string } | null;
+}
+
+export interface SyncRun {
+  startedAt: string;
+  finishedAt: string;
+  accounts: AccountRunResult[];
+  bridgeErrors: SfBridgeError[];
+}
+
+/**
+ * Runs retained. The whole history is one storage value, and the host caps
+ * values at ~250 KB; 20 runs across a realistic account count stays far below
+ * that while covering enough history to spot a recurring failure.
+ */
+export const HISTORY_LIMIT = 20;
+
+const HISTORY_KEY = storageKey('history');
+
+export async function readHistory(api: HostAPI): Promise<SyncRun[]> {
+  const raw = await api.storage.get(HISTORY_KEY);
+  if (!raw) return [];
+
+  try {
+    return JSON.parse(raw) as SyncRun[];
+  } catch (error) {
+    api.logger.error(`[simplefin] corrupt history, starting fresh: ${String(error)}`);
+    return [];
+  }
+}
+
+export async function appendRun(api: HostAPI, run: SyncRun): Promise<void> {
+  const history = await readHistory(api);
+  const next = [run, ...history].slice(0, HISTORY_LIMIT);
+  await api.storage.set(HISTORY_KEY, JSON.stringify(next));
+}

--- a/src/lib/storage/keys.test.ts
+++ b/src/lib/storage/keys.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { storageKey } from './keys';
+
+describe('storageKey', () => {
+  it('namespaces parts under the addon prefix', () => {
+    expect(storageKey('wm', 'ACT-1')).toBe('simplefin.wm.ACT-1');
+  });
+
+  it('replaces characters outside the host-allowed charset', () => {
+    // Host allows [A-Za-z0-9_.:-] only.
+    expect(storageKey('wm', 'ACT/1 2')).toBe('simplefin.wm.ACT_1_2');
+  });
+
+  it('rejects a key that exceeds the host limit of 128 characters', () => {
+    expect(() => storageKey('wm', 'x'.repeat(200))).toThrow(/128/);
+  });
+});

--- a/src/lib/storage/keys.ts
+++ b/src/lib/storage/keys.ts
@@ -1,0 +1,17 @@
+import { KEY_PREFIX } from '../constants';
+
+/** The host restricts storage keys to this charset and 128 characters. */
+const ALLOWED = /[^A-Za-z0-9_.:-]/g;
+const MAX_KEY_LENGTH = 128;
+
+export function storageKey(...parts: string[]): string {
+  const key = [KEY_PREFIX, ...parts].join('.').replace(ALLOWED, '_');
+
+  if (key.length > MAX_KEY_LENGTH) {
+    throw new Error(
+      `storage key "${key.slice(0, 32)}..." is ${key.length} chars; the host limit is ${MAX_KEY_LENGTH}`,
+    );
+  }
+
+  return key;
+}

--- a/src/lib/storage/watermark.test.ts
+++ b/src/lib/storage/watermark.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { advanceWatermark, emptyWatermark, RECENT_ID_WINDOW, shouldPush } from './watermark';
+
+const txn = (id: string, posted: number) => ({ id, posted });
+
+describe('shouldPush', () => {
+  it('pushes everything when there is no watermark yet', () => {
+    expect(shouldPush(emptyWatermark(), txn('T1', 1000))).toBe(true);
+  });
+
+  it('skips a transaction already in the recent-id window', () => {
+    const wm = { lastPosted: 2000, recentIds: ['T1'] };
+    expect(shouldPush(wm, txn('T1', 1500))).toBe(false);
+  });
+
+  it('pushes a late-posting transaction dated before the watermark if unseen', () => {
+    // The whole reason the recent-id window exists: a transaction can appear
+    // in a later fetch with a posted date earlier than the watermark.
+    const wm = { lastPosted: 2000, recentIds: ['T1'] };
+    expect(shouldPush(wm, txn('T-LATE', 1500))).toBe(true);
+  });
+
+  it('pushes a transaction newer than the watermark', () => {
+    const wm = { lastPosted: 2000, recentIds: ['T1'] };
+    expect(shouldPush(wm, txn('T2', 2500))).toBe(true);
+  });
+});
+
+describe('advanceWatermark', () => {
+  it('moves lastPosted to the newest pushed transaction', () => {
+    const wm = advanceWatermark(emptyWatermark(), [txn('T1', 1000), txn('T2', 3000)]);
+    expect(wm.lastPosted).toBe(3000);
+  });
+
+  it('never moves lastPosted backwards', () => {
+    const wm = advanceWatermark({ lastPosted: 5000, recentIds: [] }, [txn('T1', 1000)]);
+    expect(wm.lastPosted).toBe(5000);
+  });
+
+  it('records pushed ids in the recent window', () => {
+    const wm = advanceWatermark(emptyWatermark(), [txn('T1', 1000)]);
+    expect(wm.recentIds).toContain('T1');
+  });
+
+  it('bounds the recent window, evicting oldest ids first', () => {
+    const many = Array.from({ length: RECENT_ID_WINDOW + 50 }, (_, i) => txn(`T${i}`, 1000 + i));
+    const wm = advanceWatermark(emptyWatermark(), many);
+    expect(wm.recentIds).toHaveLength(RECENT_ID_WINDOW);
+    // Newest retained, oldest evicted — the window must trail the newest data.
+    expect(wm.recentIds).toContain(`T${RECENT_ID_WINDOW + 49}`);
+    expect(wm.recentIds).not.toContain('T0');
+  });
+
+  it('is a no-op when nothing was pushed', () => {
+    const before = { lastPosted: 2000, recentIds: ['T1'] };
+    expect(advanceWatermark(before, [])).toEqual(before);
+  });
+
+  it('does not duplicate an id already in the window', () => {
+    const wm = advanceWatermark({ lastPosted: 1000, recentIds: ['T1'] }, [txn('T1', 1000)]);
+    expect(wm.recentIds.filter((id) => id === 'T1')).toHaveLength(1);
+  });
+});

--- a/src/lib/storage/watermark.ts
+++ b/src/lib/storage/watermark.ts
@@ -1,0 +1,91 @@
+import type { HostAPI } from '@wealthfolio/addon-sdk';
+import { storageKey } from './keys';
+
+/**
+ * `ActivityImport` cannot carry `sourceSystem`/`sourceRecordId`, so Wealthfolio
+ * cannot dedupe our pushes for us. The addon owns idempotency instead:
+ *
+ *  - `lastPosted` — newest posted date we have successfully pushed, so the next
+ *    fetch only asks for transactions from there on.
+ *  - `recentIds` — a bounded trailing set of SimpleFIN transaction ids we have
+ *    already pushed, so a transaction that posts late (dated before the
+ *    watermark but appearing in a later fetch) is recognised rather than
+ *    re-sent.
+ *
+ * Bounded by construction: the host caps storage values at ~250 KB, which a
+ * full ledger of every synced id would eventually exceed.
+ */
+export interface Watermark {
+  /** Epoch seconds. 0 means "never synced". */
+  lastPosted: number;
+  recentIds: string[];
+}
+
+/**
+ * Size of the trailing id window. Chosen to comfortably exceed the number of
+ * transactions a single account posts within the re-fetch overlap period while
+ * keeping the serialised value far below the host's ~250 KB per-key cap
+ * (500 ids x ~40 chars is well under 25 KB).
+ */
+export const RECENT_ID_WINDOW = 500;
+
+export function emptyWatermark(): Watermark {
+  return { lastPosted: 0, recentIds: [] };
+}
+
+export interface WatermarkTxn {
+  id: string;
+  /** Epoch seconds. */
+  posted: number;
+}
+
+export function shouldPush(wm: Watermark, txn: WatermarkTxn): boolean {
+  return !wm.recentIds.includes(txn.id);
+}
+
+export function advanceWatermark(wm: Watermark, pushed: WatermarkTxn[]): Watermark {
+  if (pushed.length === 0) return wm;
+
+  const newest = pushed.reduce((max, t) => (t.posted > max ? t.posted : max), wm.lastPosted);
+
+  // Append newest-last, then keep the tail — the window must trail the newest
+  // data, so eviction takes from the front.
+  const seen = new Set(wm.recentIds);
+  const appended = [...wm.recentIds];
+  for (const t of pushed) {
+    if (!seen.has(t.id)) {
+      seen.add(t.id);
+      appended.push(t.id);
+    }
+  }
+
+  return { lastPosted: newest, recentIds: appended.slice(-RECENT_ID_WINDOW) };
+}
+
+export async function readWatermark(api: HostAPI, sfAccountId: string): Promise<Watermark> {
+  const raw = await api.storage.get(storageKey('wm', sfAccountId));
+  if (!raw) return emptyWatermark();
+  try {
+    return JSON.parse(raw) as Watermark;
+  } catch (error) {
+    // A corrupt watermark must not wedge the account. Reset to "never synced"
+    // and say so — a re-push is idempotent-ish via checkImport's duplicate
+    // detection, whereas a hard failure would block the account forever.
+    api.logger.error(
+      `[simplefin] corrupt watermark for ${sfAccountId}, resetting: ${String(error)}`,
+    );
+    return emptyWatermark();
+  }
+}
+
+export async function writeWatermark(
+  api: HostAPI,
+  sfAccountId: string,
+  wm: Watermark,
+): Promise<void> {
+  await api.storage.set(storageKey('wm', sfAccountId), JSON.stringify(wm));
+}
+
+export async function resetWatermark(api: HostAPI, sfAccountId: string): Promise<void> {
+  await api.storage.delete(storageKey('wm', sfAccountId));
+}


### PR DESCRIPTION
## Summary

- Implements Task 5 of `docs/superpowers/plans/2026-08-07-simplefin-addon-v1.md`: the addon-owned storage layer, added as four modules under `src/lib/storage/`.
- `keys.ts` — `storageKey(...parts)` namespaces under the `simplefin` prefix, sanitizes to the host-allowed `[A-Za-z0-9_.:-]` charset, and throws above the host's 128-character key limit.
- `watermark.ts` — the idempotency core. `ActivityImport` cannot carry `sourceSystem`/`sourceRecordId`, so the addon dedupes itself: a per-account `lastPosted` watermark bounds what we fetch, and a bounded trailing `recentIds` window (`RECENT_ID_WINDOW = 500`) catches late-posting transactions dated before the watermark. The window is bounded by construction so the serialized value stays far below the host's ~250KB per-key cap.
- `config.ts` — `SyncConfig` (credential-free `baseUrl` + `AccountMapping[]`) with corrupt-value recovery to an empty config rather than throwing, so a bad value sends the user back to setup instead of leaving the addon unopenable.
- `history.ts` — `SyncRun`/`AccountRunResult` with `appendRun`/`readHistory`, newest-first and bounded to `HISTORY_LIMIT = 20` runs for the same size reason.

Note: `shouldPush` dedupes purely on `recentIds` and does not consult `lastPosted` — `lastPosted` bounds what we *fetch*, not what we *push*. An id that ages out of the 500-entry window and reappears will be re-sent and must be caught by `checkImport`'s duplicate detection in Task 6.

## Test plan

- [x] `pnpm vitest run src/lib/storage` — 20 tests passing across the four new test files
- [x] `pnpm test` — full suite 43/43 passing
- [x] `pnpm type-check` (`tsc --noEmit`) — clean
- [x] Bounded-window behaviour verified explicitly: after pushing `RECENT_ID_WINDOW + 50` ids the window holds exactly 500, retains the newest id, and has evicted the oldest

## Issues

<!-- List every issue this PR resolves. Required — the board automation depends on these lines. -->

Closes #8
