### PR TITLE
feat: sync SimpleFIN cash transactions with watermark-based idempotency

### DIFF
--- a/src/lib/sync/activities.test.ts
+++ b/src/lib/sync/activities.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ActivityImport } from '@wealthfolio/addon-sdk';
+import { createMockHost } from '../../test/mockHost';
+import type { AccountMapping } from '../storage/config';
+import { emptyWatermark } from '../storage/watermark';
+import { syncCashAccount, toActivityImport } from './activities';
+
+const mapping: AccountMapping = {
+  sfAccountId: 'ACT-1',
+  wfAccountId: 'WF-1',
+  mode: 'CASH',
+  sfAccountName: 'Checking',
+  orgName: 'Test Bank',
+};
+
+const txn = (over: Partial<Record<string, unknown>> = {}) => ({
+  id: 'TXN-1',
+  posted: 1754438400,
+  amount: '-42.10',
+  description: 'COFFEE',
+  payee: 'Blue Bottle',
+  memo: null,
+  pending: false,
+  ...over,
+});
+
+describe('toActivityImport', () => {
+  it('maps a negative amount to a WITHDRAWAL with positive magnitude', () => {
+    const activity = toActivityImport(txn() as never, mapping, 'USD');
+    expect(activity.activityType).toBe('WITHDRAWAL');
+    expect(activity.amount).toBe('42.10');
+    expect(activity.accountId).toBe('WF-1');
+    expect(activity.currency).toBe('USD');
+  });
+
+  it('maps a positive amount to a DEPOSIT', () => {
+    const activity = toActivityImport(txn({ amount: '2000.00' }) as never, mapping, 'USD');
+    expect(activity.activityType).toBe('DEPOSIT');
+    expect(activity.amount).toBe('2000.00');
+  });
+
+  it('keeps the amount as a string to avoid float rounding', () => {
+    const activity = toActivityImport(txn({ amount: '-0.1' }) as never, mapping, 'USD');
+    expect(typeof activity.amount).toBe('string');
+    expect(activity.amount).toBe('0.1');
+  });
+
+  it('prefers payee over description for the comment, falling back to description', () => {
+    expect(toActivityImport(txn() as never, mapping, 'USD').comment).toBe('Blue Bottle');
+    expect(toActivityImport(txn({ payee: null }) as never, mapping, 'USD').comment).toBe('COFFEE');
+  });
+
+  it('converts the epoch posted date to an ISO date', () => {
+    const activity = toActivityImport(txn() as never, mapping, 'USD');
+    expect(activity.date).toBe('2025-08-06');
+  });
+});
+
+describe('syncCashAccount', () => {
+  const account = (transactions: unknown[]) => ({
+    id: 'ACT-1',
+    name: 'Checking',
+    currency: 'USD',
+    balance: '100.00',
+    balanceDate: 1754524800,
+    orgName: 'Test Bank',
+    transactions,
+    holdings: [],
+  });
+
+  it('skips pending transactions', async () => {
+    const host = createMockHost();
+    host.api.activities.checkImport = vi.fn(async (a) => a);
+    host.api.activities.import = vi.fn(async () => ({
+      activities: [],
+      importRunId: 'R1',
+      summary: { total: 0, imported: 0, skipped: 0, duplicates: 0, assetsCreated: 0, success: true },
+    }));
+
+    await syncCashAccount(
+      host.api,
+      mapping,
+      account([txn({ pending: true })]) as never,
+      emptyWatermark(),
+    );
+
+    expect(host.api.activities.import).not.toHaveBeenCalled();
+  });
+
+  it('skips transactions already in the recent-id window', async () => {
+    const host = createMockHost();
+    host.api.activities.checkImport = vi.fn(async (a) => a);
+
+    await syncCashAccount(host.api, mapping, account([txn()]) as never, {
+      lastPosted: 1754438400,
+      recentIds: ['TXN-1'],
+    });
+
+    expect(host.api.activities.import).not.toHaveBeenCalled();
+  });
+
+  it('validates via checkImport before importing', async () => {
+    const host = createMockHost();
+    const order: string[] = [];
+    host.api.activities.checkImport = vi.fn(async (a) => {
+      order.push('check');
+      return a;
+    });
+    host.api.activities.import = vi.fn(async () => {
+      order.push('import');
+      return {
+        activities: [],
+        importRunId: 'R1',
+        summary: {
+          total: 1,
+          imported: 1,
+          skipped: 0,
+          duplicates: 0,
+          assetsCreated: 0,
+          success: true,
+        },
+      };
+    });
+
+    await syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark());
+    expect(order).toEqual(['check', 'import']);
+  });
+
+  it('does not import rows the host flagged as duplicates', async () => {
+    const host = createMockHost();
+    host.api.activities.checkImport = vi.fn(async (a: ActivityImport[]) =>
+      a.map((row) => ({ ...row, duplicateOfId: 'EXISTING', isValid: true })),
+    );
+    host.api.activities.import = vi.fn();
+
+    const { result } = await syncCashAccount(
+      host.api,
+      mapping,
+      account([txn()]) as never,
+      emptyWatermark(),
+    );
+
+    expect(host.api.activities.import).not.toHaveBeenCalled();
+    expect(result.duplicates).toBe(1);
+  });
+
+  it('does not import rows checkImport marked invalid', async () => {
+    const host = createMockHost();
+    host.api.activities.checkImport = vi.fn(async (a: ActivityImport[]) =>
+      a.map((row) => ({ ...row, isValid: false, errors: { amount: ['bad'] } })),
+    );
+    host.api.activities.import = vi.fn();
+
+    const { result } = await syncCashAccount(
+      host.api,
+      mapping,
+      account([txn()]) as never,
+      emptyWatermark(),
+    );
+
+    expect(host.api.activities.import).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+
+  it('advances the watermark only over transactions actually imported', async () => {
+    const host = createMockHost();
+    host.api.activities.checkImport = vi.fn(async (a) => a);
+    host.api.activities.import = vi.fn(async () => ({
+      activities: [],
+      importRunId: 'R1',
+      summary: { total: 1, imported: 1, skipped: 0, duplicates: 0, assetsCreated: 0, success: true },
+    }));
+
+    const { watermark } = await syncCashAccount(
+      host.api,
+      mapping,
+      account([txn()]) as never,
+      emptyWatermark(),
+    );
+
+    expect(watermark.lastPosted).toBe(1754438400);
+    expect(watermark.recentIds).toContain('TXN-1');
+  });
+
+  it('leaves the watermark untouched when the import throws', async () => {
+    const host = createMockHost();
+    host.api.activities.checkImport = vi.fn(async (a) => a);
+    host.api.activities.import = vi.fn(async () => {
+      throw new Error('host exploded');
+    });
+
+    const before = emptyWatermark();
+    await expect(
+      syncCashAccount(host.api, mapping, account([txn()]) as never, before),
+    ).rejects.toThrow(/host exploded/);
+  });
+});

--- a/src/lib/sync/activities.ts
+++ b/src/lib/sync/activities.ts
@@ -1,0 +1,104 @@
+import type { ActivityImport, HostAPI } from '@wealthfolio/addon-sdk';
+import type { SfAccount, SfTransaction } from '../simplefin/parse';
+import type { AccountMapping } from '../storage/config';
+import { advanceWatermark, shouldPush, type Watermark } from '../storage/watermark';
+
+/** Epoch seconds -> YYYY-MM-DD in UTC, the form Wealthfolio's importer expects. */
+function isoDate(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toISOString().slice(0, 10);
+}
+
+/**
+ * SimpleFIN signs amounts (negative = money out); Wealthfolio splits direction
+ * into the activity type and expects a positive magnitude. The string is kept
+ * as a string throughout — parsing to a float would round real money.
+ */
+export function toActivityImport(
+  txn: SfTransaction,
+  mapping: AccountMapping,
+  currency: string,
+): ActivityImport {
+  const isOutflow = txn.amount.trim().startsWith('-');
+  const magnitude = txn.amount.trim().replace(/^-/, '');
+
+  return {
+    accountId: mapping.wfAccountId,
+    activityType: isOutflow ? 'WITHDRAWAL' : 'DEPOSIT',
+    date: isoDate(txn.posted),
+    amount: magnitude,
+    currency,
+    comment: txn.payee || txn.description,
+    isValid: true,
+    isDraft: false,
+  };
+}
+
+export interface CashSyncCounts {
+  imported: number;
+  skipped: number;
+  duplicates: number;
+}
+
+export async function syncCashAccount(
+  api: HostAPI,
+  mapping: AccountMapping,
+  sfAccount: SfAccount,
+  watermark: Watermark,
+): Promise<{ result: CashSyncCounts; watermark: Watermark }> {
+  // Pending transactions are excluded from v1: their id and amount can both
+  // change once posted, which would push a row we could never reconcile.
+  const candidates = sfAccount.transactions.filter((t) => !t.pending && shouldPush(watermark, t));
+
+  if (candidates.length === 0) {
+    return { result: { imported: 0, skipped: 0, duplicates: 0 }, watermark };
+  }
+
+  const rows = candidates.map((t) => toActivityImport(t, mapping, sfAccount.currency));
+  const checked = await api.activities.checkImport(rows);
+
+  // checkImport annotates each row. Host-detected duplicates are a secondary
+  // guard behind our own watermark; we never force-import over them.
+  const importable: ActivityImport[] = [];
+  const importableTxns: SfTransaction[] = [];
+  let duplicates = 0;
+  let skipped = 0;
+
+  checked.forEach((row, index) => {
+    if (row.duplicateOfId || row.duplicateOfLineNumber !== undefined) {
+      duplicates += 1;
+      return;
+    }
+    if (!row.isValid) {
+      skipped += 1;
+      api.logger.error(
+        `[simplefin] row rejected by checkImport for ${mapping.sfAccountName}: ` +
+          JSON.stringify(row.errors ?? {}),
+      );
+      return;
+    }
+    importable.push(row);
+    importableTxns.push(candidates[index]);
+  });
+
+  if (importable.length === 0) {
+    // Rows duplicating an activity Wealthfolio already holds (`duplicateOfId`)
+    // are genuinely present on the other side, so the watermark may advance
+    // over them — otherwise every run re-checks the same rows forever. Rows
+    // flagged only by `duplicateOfLineNumber` duplicate another row in *this*
+    // batch, which was itself never imported here, so those must not advance.
+    const advanced = advanceWatermark(
+      watermark,
+      candidates.filter((_, i) => checked[i].duplicateOfId),
+    );
+    return { result: { imported: 0, skipped, duplicates }, watermark: advanced };
+  }
+
+  const outcome = await api.activities.import(importable);
+
+  return {
+    result: { imported: outcome.summary.imported, skipped, duplicates },
+    // Only advance over what was actually accepted — if the import throws, this
+    // line is never reached and the watermark stays put, so the next run retries.
+    watermark: advanceWatermark(watermark, importableTxns),
+  };
+}


### PR DESCRIPTION
## Summary

- Implements Task 6 of `docs/superpowers/plans/2026-08-07-simplefin-addon-v1.md`: cash transaction sync, as `src/lib/sync/activities.ts`.
- `toActivityImport(txn, mapping, currency)` — SimpleFIN signs amounts (negative = money out); Wealthfolio splits direction into the activity type, so the sign becomes `WITHDRAWAL`/`DEPOSIT` and `amount` carries a positive magnitude. The magnitude stays a **string** end to end — parsing to a float would round real money. `posted` (epoch seconds) becomes a UTC `YYYY-MM-DD` date; `comment` prefers `payee` and falls back to `description`.
- `syncCashAccount(api, mapping, sfAccount, watermark)` — filters out pending transactions (v1 scope: their id and amount can both change once posted) and anything already in the watermark's `recentIds` window, then `checkImport()` → `import()`. Rows the host flags as duplicates or marks invalid are never force-imported; invalid rows are logged through `api.logger.error` with account attribution (project rule 2).
- Watermark advances only over rows actually accepted. If `import()` throws, the advance line is never reached and the watermark stays put, so the next run retries. Where nothing was importable because Wealthfolio already holds the rows (`duplicateOfId`), the watermark still advances over those — otherwise every run re-checks the same rows forever. Rows flagged only by `duplicateOfLineNumber` duplicate another row in the *same* batch, which was itself never imported here, so those deliberately do not advance.

This closes the loop opened in #8: `shouldPush` dedupes on `recentIds` only, so an id that ages out of the 500-entry window and reappears is caught here by `checkImport`'s duplicate detection rather than being re-sent.

### Deviations from the plan

- The plan's fixture asserted `date === '2026-08-06'` for `posted: 1754438400`, but that epoch is `2025-08-06T00:00:00Z`. The expectation was off by a year; the implementation was correct. Corrected to `'2025-08-06'`.
- The plan's two `checkImport` mocks left their callback parameter untyped, which fails `tsc --noEmit` under `noImplicitAny`. Annotated as `ActivityImport[]` rather than suppressing the error (project rule 3).
- Dropped the plan's redundant `as ActivityImport['activityType']` cast — `ActivityType` is a literal union and the ternary is already assignable.

## Test plan

- [x] `pnpm vitest run src/lib/sync/activities.test.ts` — 12 tests passing
- [x] `pnpm test` — full suite 55/55 passing
- [x] `pnpm type-check` (`tsc --noEmit`) — clean
- [x] **Transform verified against a real Bridge payload (project rule 1)** — ran the parse → transform chain over the live SimpleFIN demo Bridge (`beta-bridge.simplefin.org`, 169 transactions/account over a 400-day window) via a throwaway harness, since passing tests are not sufficient for a data transformation. Confirmed by eye:
  - sign direction — `-60.00` → `WITHDRAWAL` / `60.00`; `1960.00` and `2564.48` → `DEPOSIT`, unchanged
  - dates are the posted dates — `1786521600` → `2026-08-12`, matching the payload's `posted`
  - no float artefacts — `65.50`, `78.85`, `2564.48` round-trip byte-for-byte as strings
  - the harness was deleted before commit and is not part of this PR

Two observations from the live payload, neither changed in this PR:

- The demo Bridge emits a zero-amount transaction (`'00.00'`), which maps to a `DEPOSIT` of `00.00`. That is faithful passthrough; `checkImport` is the right place to reject it if Wealthfolio objects. Flagging rather than adding unrequested filtering.
- Transaction ids collide **across** accounts in the demo data (`1779984000` appears in both Savings and Checking). Watermarks are keyed per `sfAccountId`, so this is handled — but it confirms the per-account keying is load-bearing, not incidental.

## Issues

<!-- List every issue this PR resolves. Required — the board automation depends on these lines. -->

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
