### PR TITLE
feat: sync SimpleFIN holdings as Wealthfolio snapshots

### DIFF
--- a/src/lib/sync/snapshots.test.ts
+++ b/src/lib/sync/snapshots.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createMockHost } from '../../test/mockHost';
+import type { AccountMapping } from '../storage/config';
+import { syncHoldingsAccount, toSnapshotInput } from './snapshots';
+
+const mapping: AccountMapping = {
+  sfAccountId: 'ACT-2',
+  wfAccountId: 'WF-2',
+  mode: 'HOLDINGS',
+  sfAccountName: 'Brokerage',
+  orgName: 'Test Broker',
+};
+
+const account = (holdings: unknown[], balance = '500.00') => ({
+  id: 'ACT-2',
+  name: 'Brokerage',
+  currency: 'USD',
+  balance,
+  balanceDate: 1754524800,
+  orgName: 'Test Broker',
+  transactions: [],
+  holdings,
+});
+
+const holding = (over = {}) => ({
+  symbol: 'AAPL',
+  shares: '10',
+  currency: 'USD',
+  costBasis: '1500.00',
+  purchasePrice: '150.00',
+  marketValue: '2000.00',
+  ...over,
+});
+
+describe('toSnapshotInput', () => {
+  it('maps holdings to positions dated by the balance date', () => {
+    const snapshot = toSnapshotInput(account([holding()]) as never);
+    expect(snapshot.date).toBe('2025-08-07');
+    expect(snapshot.positions).toEqual([
+      { symbol: 'AAPL', quantity: '10', avgCost: '150.00', currency: 'USD' },
+    ]);
+  });
+
+  it('carries the account cash balance', () => {
+    const snapshot = toSnapshotInput(account([holding()]) as never);
+    expect(snapshot.cashBalances).toEqual({ USD: '500.00' });
+  });
+
+  it('drops holdings with no symbol, which cannot be resolved to an asset', () => {
+    const snapshot = toSnapshotInput(account([holding({ symbol: '' })]) as never);
+    expect(snapshot.positions).toEqual([]);
+  });
+
+  it('drops holdings with no share count', () => {
+    const snapshot = toSnapshotInput(account([holding({ shares: null })]) as never);
+    expect(snapshot.positions).toEqual([]);
+  });
+});
+
+describe('syncHoldingsAccount', () => {
+  it('skips a snapshot whose date already exists', async () => {
+    const host = createMockHost();
+    host.api.snapshots.checkImport = vi.fn(async () => ({
+      existingDates: ['2025-08-07'],
+      symbols: [],
+      validationErrors: [],
+    }));
+    host.api.snapshots.importSnapshots = vi.fn();
+
+    const result = await syncHoldingsAccount(host.api, mapping, account([holding()]) as never);
+
+    expect(host.api.snapshots.importSnapshots).not.toHaveBeenCalled();
+    expect(result).toEqual({ imported: 0, skipped: 1 });
+  });
+
+  it('imports a snapshot for a new date', async () => {
+    const host = createMockHost();
+    host.api.snapshots.checkImport = vi.fn(async () => ({
+      existingDates: [],
+      symbols: [],
+      validationErrors: [],
+    }));
+    host.api.snapshots.importSnapshots = vi.fn(async () => ({
+      snapshotsImported: 1,
+      snapshotsFailed: 0,
+      errors: [],
+    }));
+
+    const result = await syncHoldingsAccount(host.api, mapping, account([holding()]) as never);
+
+    expect(host.api.snapshots.importSnapshots).toHaveBeenCalledWith('WF-2', expect.any(Array));
+    expect(result).toEqual({ imported: 1, skipped: 0 });
+  });
+
+  it('throws when checkImport reports validation errors', async () => {
+    const host = createMockHost();
+    host.api.snapshots.checkImport = vi.fn(async () => ({
+      existingDates: [],
+      symbols: [],
+      validationErrors: ['unknown symbol ZZZZ'],
+    }));
+
+    await expect(
+      syncHoldingsAccount(host.api, mapping, account([holding()]) as never),
+    ).rejects.toThrow(/unknown symbol ZZZZ/);
+  });
+
+  it('does nothing for an account with no holdings', async () => {
+    const host = createMockHost();
+    host.api.snapshots.checkImport = vi.fn();
+
+    const result = await syncHoldingsAccount(host.api, mapping, account([]) as never);
+
+    expect(host.api.snapshots.checkImport).not.toHaveBeenCalled();
+    expect(result).toEqual({ imported: 0, skipped: 0 });
+  });
+});

--- a/src/lib/sync/snapshots.ts
+++ b/src/lib/sync/snapshots.ts
@@ -1,0 +1,58 @@
+import type { HostAPI, SnapshotInput } from '@wealthfolio/addon-sdk';
+import type { SfAccount } from '../simplefin/parse';
+import type { AccountMapping } from '../storage/config';
+
+/** Epoch seconds -> YYYY-MM-DD in UTC, the form Wealthfolio's importer expects. */
+function isoDate(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toISOString().slice(0, 10);
+}
+
+export function toSnapshotInput(sfAccount: SfAccount): SnapshotInput {
+  const positions = sfAccount.holdings
+    // A position with no symbol or no share count cannot be resolved to a
+    // Wealthfolio asset; sending it would fail validation for the whole batch.
+    .filter((h) => h.symbol !== '' && h.shares !== null)
+    .map((h) => ({
+      symbol: h.symbol,
+      quantity: h.shares as string,
+      avgCost: h.purchasePrice ?? undefined,
+      currency: h.currency ?? sfAccount.currency,
+    }));
+
+  return {
+    date: isoDate(sfAccount.balanceDate),
+    positions,
+    cashBalances: { [sfAccount.currency]: sfAccount.balance },
+  };
+}
+
+export async function syncHoldingsAccount(
+  api: HostAPI,
+  mapping: AccountMapping,
+  sfAccount: SfAccount,
+): Promise<{ imported: number; skipped: number }> {
+  if (sfAccount.holdings.length === 0) {
+    return { imported: 0, skipped: 0 };
+  }
+
+  const snapshot = toSnapshotInput(sfAccount);
+  const check = await api.snapshots.checkImport(mapping.wfAccountId, [snapshot]);
+
+  if (check.validationErrors.length > 0) {
+    throw new Error(`snapshot rejected: ${check.validationErrors.join('; ')}`);
+  }
+
+  // `existingDates` is the host-side idempotency signal — holdings need no
+  // local watermark because re-importing a known date is detectable here.
+  if (check.existingDates.includes(snapshot.date)) {
+    return { imported: 0, skipped: 1 };
+  }
+
+  const outcome = await api.snapshots.importSnapshots(mapping.wfAccountId, [snapshot]);
+
+  if (outcome.errors.length > 0) {
+    throw new Error(`snapshot import failed: ${outcome.errors.join('; ')}`);
+  }
+
+  return { imported: outcome.snapshotsImported, skipped: 0 };
+}


### PR DESCRIPTION
## Summary

- Implements Task 7 of `docs/superpowers/plans/2026-08-07-simplefin-addon-v1.md`: holdings snapshot sync, as `src/lib/sync/snapshots.ts`.
- `toSnapshotInput(sfAccount)` — maps `SfAccount.holdings` to a `SnapshotInput`, dated by the account's `balance-date` converted to a UTC `YYYY-MM-DD` (same convention as `activities.ts`), with the account's cash balance carried as `cashBalances: { [currency]: balance }`. Every figure stays a **string** end to end. Holdings with no `symbol` or no `shares` are dropped — neither can be resolved to a Wealthfolio asset, and sending one would fail validation for the whole batch rather than just that row.
- `syncHoldingsAccount(api, mapping, sfAccount)` — `checkImport()` → throw on `validationErrors` → skip if `existingDates` already contains the snapshot date → `importSnapshots()`, throwing on any returned `errors`.
- **No watermark.** Unlike cash sync (#9), holdings need no local dedupe state: `CheckSnapshotImportResult.existingDates` is a host-side idempotency signal, so a re-run over a date Wealthfolio already holds is detectable at the boundary. This is the one place the addon can honour the `wf-simplefin` statelessness invariant for free.

### Deviations from the plan

- The plan's fixture asserted `date === '2026-08-07'` for `balanceDate: 1754524800`, but that epoch is `2025-08-07T00:00:00Z` — the same off-by-a-year the plan had for Task 6 (see #40). The fixture is consistent with every other test in the repo, so the expectation was corrected to `'2025-08-07'`, not the fixture. **The plan file still carries the wrong value at line 1841 and Task 8 reuses these fixtures**, so it will need the same correction there.

## Test plan

- [x] `pnpm vitest run src/lib/sync/snapshots.test.ts` — 8 tests passing (the count the issue asks for)
- [x] `pnpm test` — full suite 63/63 passing
- [x] `pnpm type-check` (`tsc --noEmit`) — clean
- [x] **Transform verified against a real Bridge payload (project rule 1)** — ran the `parseAccountsResponse` → `toSnapshotInput` chain over the live SimpleFIN demo Bridge (`beta-bridge.simplefin.org`) via a throwaway harness, since passing tests are not sufficient for a data transformation. The harness was deleted before commit and is not part of this PR. Confirmed against the real holding:

  Bridge emitted `{"symbol":"AAPL","shares":"550.0","purchase_price":"0.10","cost_basis":"55.00","market_value":"105884.8","currency":"USD"}` on `Demo Savings` (`balance-date` 1786579200, balance `113845.51`), and the transform produced:

  ```json
  { "date": "2026-08-13",
    "positions": [{ "symbol": "AAPL", "quantity": "550.0", "avgCost": "0.10", "currency": "USD" }],
    "cashBalances": { "USD": "113845.51" } }
  ```

  - **`avgCost` semantics confirmed, not assumed** — `cost_basis` 55.00 = `purchase_price` 0.10 x `shares` 550.0, so SimpleFIN's `purchase_price` is per-share average cost, which is exactly what `SnapshotPositionInput.avgCost` means. This was the one mapping in the task that could have been silently wrong in a way tests with invented fixtures would never catch.
  - **No float artefacts** — `550.0`, `0.10`, `113845.51`, `0.00` all round-trip byte-for-byte as strings.
  - **Date conversion is real** — `1786579200` → `2026-08-13`, matching the payload's `balance-date`.
  - `market_value` is correctly unused; Wealthfolio values positions from its own quote data.

## Observations, neither changed in this PR

- **An all-cash brokerage pushes no snapshot at all.** `syncHoldingsAccount` returns early when `holdings.length === 0` (the plan asserts this explicitly), so the `cashBalances` figure only ever reaches Wealthfolio alongside at least one position. A HOLDINGS-mapped account whose positions were all sold would silently stop snapshotting rather than recording its cash. `balance.ts` in Task 8 only *reports* mismatches, it does not push, so this is worth a decision during orchestration rather than a silent gap. Flagging rather than adding unrequested behaviour.
- **`checkImport` validation errors fail the whole account.** One unresolvable symbol throws for the entire snapshot, not just that position. That is the correct blast radius for a snapshot (a partial snapshot is a wrong snapshot, unlike a partial transaction batch), and Task 8's per-account isolation is what keeps it from taking down other institutions — but it does mean one unknown ticker stops that brokerage syncing until it resolves.

## Issues

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
