### PR TITLE
feat: orchestrate sync with per-account failure isolation

### DIFF
--- a/src/lib/sync/balance.test.ts
+++ b/src/lib/sync/balance.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { compareBalances } from './balance';
+
+describe('compareBalances', () => {
+  it('reports no mismatch for equal balances', () => {
+    expect(compareBalances('100.00', '100.00')).toBeNull();
+  });
+
+  it('treats differing decimal representations of the same value as equal', () => {
+    expect(compareBalances('100.0', '100.00')).toBeNull();
+    expect(compareBalances('-0.00', '0.00')).toBeNull();
+  });
+
+  it('reports a mismatch with both figures', () => {
+    expect(compareBalances('100.00', '90.00')).toEqual({
+      simplefin: '100.00',
+      wealthfolio: '90.00',
+    });
+  });
+
+  it('returns null when the Wealthfolio balance is unavailable', () => {
+    // Rule: if a value cannot be computed, return null rather than a magic number.
+    expect(compareBalances('100.00', null)).toBeNull();
+  });
+});

--- a/src/lib/sync/balance.ts
+++ b/src/lib/sync/balance.ts
@@ -1,0 +1,34 @@
+/**
+ * Compare two decimal strings without going through float. Balances are
+ * compared by normalised value, so "100.0" and "100.00" agree.
+ */
+function normalise(value: string): string {
+  const trimmed = value.trim();
+  const negative = trimmed.startsWith('-');
+  const [whole, fraction = ''] = trimmed.replace(/^[-+]/, '').split('.');
+  const cleanWhole = whole.replace(/^0+(?=\d)/, '');
+  const cleanFraction = fraction.replace(/0+$/, '');
+  const magnitude = cleanFraction ? `${cleanWhole}.${cleanFraction}` : cleanWhole;
+
+  // -0 and 0 are the same balance.
+  if (/^0(\.0*)?$/.test(magnitude)) return '0';
+  return negative ? `-${magnitude}` : magnitude;
+}
+
+export interface BalanceMismatch {
+  simplefin: string;
+  wealthfolio: string;
+}
+
+export function compareBalances(
+  simplefin: string,
+  wealthfolio: string | null,
+): BalanceMismatch | null {
+  // No Wealthfolio figure means the check could not be computed — report
+  // nothing rather than inventing a comparison.
+  if (wealthfolio === null) return null;
+
+  return normalise(simplefin) === normalise(wealthfolio)
+    ? null
+    : { simplefin, wealthfolio };
+}

--- a/src/lib/sync/run.test.ts
+++ b/src/lib/sync/run.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ActivityImport } from '@wealthfolio/addon-sdk';
+import { createMockHost } from '../../test/mockHost';
+import type { SyncConfig } from '../storage/config';
+import { runSync } from './run';
+
+const config: SyncConfig = {
+  baseUrl: 'https://bridge.simplefin.org/simplefin',
+  mappings: [
+    {
+      sfAccountId: 'ACT-1',
+      wfAccountId: 'WF-1',
+      mode: 'CASH',
+      sfAccountName: 'Checking',
+      orgName: 'Bank A',
+    },
+    {
+      sfAccountId: 'ACT-2',
+      wfAccountId: 'WF-2',
+      mode: 'CASH',
+      sfAccountName: 'Savings',
+      orgName: 'Bank B',
+    },
+  ],
+};
+
+const bridgePayload = {
+  errors: [],
+  accounts: [
+    {
+      org: { name: 'Bank A' },
+      id: 'ACT-1',
+      name: 'Checking',
+      currency: 'USD',
+      balance: '100.00',
+      'balance-date': 1754524800,
+      transactions: [{ id: 'T1', posted: 1754438400, amount: '-10.00', description: 'X' }],
+      holdings: [],
+    },
+    {
+      org: { name: 'Bank B' },
+      id: 'ACT-2',
+      name: 'Savings',
+      currency: 'USD',
+      balance: '200.00',
+      'balance-date': 1754524800,
+      transactions: [{ id: 'T2', posted: 1754438400, amount: '-20.00', description: 'Y' }],
+      holdings: [],
+    },
+  ],
+};
+
+function okHost() {
+  const host = createMockHost();
+  host.respond(/\/accounts/, { body: JSON.stringify(bridgePayload) });
+  host.api.activities.checkImport = vi.fn(async (a: ActivityImport[]) => a);
+  host.api.activities.import = vi.fn(async () => ({
+    activities: [],
+    importRunId: 'R',
+    summary: { total: 1, imported: 1, skipped: 0, duplicates: 0, assetsCreated: 0, success: true },
+  }));
+  host.api.accounts.getAll = vi.fn(async () => []);
+  return host;
+}
+
+describe('runSync', () => {
+  it('syncs every mapped account', async () => {
+    const run = await runSync(okHost().api, config);
+    expect(run.accounts).toHaveLength(2);
+    expect(run.accounts.every((a) => a.error === null)).toBe(true);
+  });
+
+  it('isolates a per-account failure so the others still sync', async () => {
+    const host = okHost();
+    host.api.activities.import = vi.fn(async (rows: ActivityImport[]) => {
+      if (rows[0].accountId === 'WF-1') throw new Error('WF-1 exploded');
+      return {
+        activities: [],
+        importRunId: 'R',
+        summary: {
+          total: 1,
+          imported: 1,
+          skipped: 0,
+          duplicates: 0,
+          assetsCreated: 0,
+          success: true,
+        },
+      };
+    });
+
+    const run = await runSync(host.api, config);
+
+    const first = run.accounts.find((a) => a.wfAccountId === 'WF-1');
+    const second = run.accounts.find((a) => a.wfAccountId === 'WF-2');
+    expect(first?.error).toMatch(/exploded/);
+    expect(second?.error).toBeNull();
+    expect(second?.imported).toBe(1);
+  });
+
+  it('records bridge errors without aborting the run', async () => {
+    const host = createMockHost();
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        ...bridgePayload,
+        errlist: [{ code: 'AUTH', msg: 'Reauthenticate Bank A', conn_id: 'C1' }],
+      }),
+    });
+    host.api.activities.checkImport = vi.fn(async (a: ActivityImport[]) => a);
+    host.api.activities.import = vi.fn(async () => ({
+      activities: [],
+      importRunId: 'R',
+      summary: { total: 1, imported: 1, skipped: 0, duplicates: 0, assetsCreated: 0, success: true },
+    }));
+    host.api.accounts.getAll = vi.fn(async () => []);
+
+    const run = await runSync(host.api, config);
+    expect(run.bridgeErrors).toHaveLength(1);
+    expect(run.accounts).toHaveLength(2);
+  });
+
+  it('records an account mapped to an id the Bridge did not return', async () => {
+    const host = okHost();
+    const run = await runSync(host.api, {
+      ...config,
+      mappings: [
+        ...config.mappings,
+        {
+          sfAccountId: 'GONE',
+          wfAccountId: 'WF-3',
+          mode: 'CASH',
+          sfAccountName: 'Old',
+          orgName: 'Bank C',
+        },
+      ],
+    });
+    const missing = run.accounts.find((a) => a.wfAccountId === 'WF-3');
+    expect(missing?.error).toMatch(/not returned by the Bridge/i);
+  });
+
+  it('persists the run to history', async () => {
+    const host = okHost();
+    await runSync(host.api, config);
+    expect(host.storage.has('simplefin.history')).toBe(true);
+  });
+
+  it('throws when there is no configured base URL', async () => {
+    const host = okHost();
+    await expect(runSync(host.api, { ...config, baseUrl: null })).rejects.toThrow(/not connected/i);
+  });
+});

--- a/src/lib/sync/run.ts
+++ b/src/lib/sync/run.ts
@@ -1,0 +1,141 @@
+import type { HostAPI } from '@wealthfolio/addon-sdk';
+import { fetchAccounts } from '../simplefin/client';
+import type { SfAccount } from '../simplefin/parse';
+import type { AccountMapping, SyncConfig } from '../storage/config';
+import { appendRun, type AccountRunResult, type SyncRun } from '../storage/history';
+import { readWatermark, writeWatermark } from '../storage/watermark';
+import { syncCashAccount } from './activities';
+import { compareBalances } from './balance';
+import { syncHoldingsAccount } from './snapshots';
+
+/**
+ * Re-fetch overlap. The Bridge can post a transaction days after its posted
+ * date, so each run asks for a window before the watermark and relies on the
+ * recent-id set to discard what we already pushed.
+ */
+const OVERLAP_DAYS = 7;
+const SECONDS_PER_DAY = 86_400;
+
+async function syncOne(
+  api: HostAPI,
+  mapping: AccountMapping,
+  sfAccount: SfAccount | undefined,
+  wfBalances: Map<string, string>,
+): Promise<AccountRunResult> {
+  const base: AccountRunResult = {
+    sfAccountId: mapping.sfAccountId,
+    sfAccountName: mapping.sfAccountName,
+    orgName: mapping.orgName,
+    wfAccountId: mapping.wfAccountId,
+    mode: mapping.mode,
+    imported: null,
+    skipped: null,
+    duplicates: null,
+    error: null,
+    balanceMismatch: null,
+  };
+
+  if (!sfAccount) {
+    return {
+      ...base,
+      error:
+        `SimpleFIN account ${mapping.sfAccountId} was not returned by the Bridge. ` +
+        'It may have been disconnected — re-check the mapping.',
+    };
+  }
+
+  try {
+    if (mapping.mode === 'HOLDINGS') {
+      const { imported, skipped } = await syncHoldingsAccount(api, mapping, sfAccount);
+      return {
+        ...base,
+        imported,
+        skipped,
+        duplicates: 0,
+        balanceMismatch: compareBalances(
+          sfAccount.balance,
+          wfBalances.get(mapping.wfAccountId) ?? null,
+        ),
+      };
+    }
+
+    const watermark = await readWatermark(api, mapping.sfAccountId);
+    const { result, watermark: next } = await syncCashAccount(api, mapping, sfAccount, watermark);
+    await writeWatermark(api, mapping.sfAccountId, next);
+
+    return {
+      ...base,
+      imported: result.imported,
+      skipped: result.skipped,
+      duplicates: result.duplicates,
+      balanceMismatch: compareBalances(
+        sfAccount.balance,
+        wfBalances.get(mapping.wfAccountId) ?? null,
+      ),
+    };
+  } catch (error) {
+    // Per-institution isolation is a hard invariant: record and continue.
+    const message = error instanceof Error ? error.message : String(error);
+    api.logger.error(`[simplefin] account ${mapping.sfAccountName} failed: ${message}`);
+    return { ...base, error: message };
+  }
+}
+
+export async function runSync(api: HostAPI, config: SyncConfig): Promise<SyncRun> {
+  if (!config.baseUrl) {
+    throw new Error('Not connected to SimpleFIN — claim a setup token first.');
+  }
+
+  const startedAt = new Date().toISOString();
+
+  // One fetch covers every account; the Bridge bills per call, and a single
+  // response also lets one institution's error surface alongside healthy data.
+  // The window starts at the oldest watermark so no account is short-changed.
+  const watermarks = await Promise.all(
+    config.mappings.map((m) => readWatermark(api, m.sfAccountId)),
+  );
+  const oldest = watermarks.reduce(
+    (min, wm) => (wm.lastPosted > 0 && wm.lastPosted < min ? wm.lastPosted : min),
+    Number.POSITIVE_INFINITY,
+  );
+  const startDate = Number.isFinite(oldest)
+    ? Math.max(0, oldest - OVERLAP_DAYS * SECONDS_PER_DAY)
+    : undefined;
+
+  const { accounts, errors } = await fetchAccounts(api.network, config.baseUrl, {
+    startDate,
+    accountIds: config.mappings.map((m) => m.sfAccountId),
+  });
+
+  const bySfId = new Map(accounts.map((a) => [a.id, a]));
+
+  // Wealthfolio balances for the post-sync mismatch check. A failure here must
+  // not fail the run — the check is diagnostic, so it degrades to "unavailable".
+  const wfBalances = new Map<string, string>();
+  try {
+    for (const account of await api.accounts.getAll()) {
+      if (Number.isFinite(account.balance)) wfBalances.set(account.id, String(account.balance));
+    }
+  } catch (error) {
+    api.logger.error(
+      `[simplefin] could not read Wealthfolio balances for the mismatch check: ${String(error)}`,
+    );
+  }
+
+  // Sequential on purpose: the host import APIs are shared state, and a serial
+  // run keeps one slow institution from being blamed for another's timeout.
+  const results: AccountRunResult[] = [];
+  for (const mapping of config.mappings) {
+    results.push(await syncOne(api, mapping, bySfId.get(mapping.sfAccountId), wfBalances));
+  }
+
+  const run: SyncRun = {
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    accounts: results,
+    bridgeErrors: errors,
+  };
+
+  await appendRun(api, run);
+  return run;
+}


### PR DESCRIPTION
Task 8 of `docs/superpowers/plans/2026-08-07-simplefin-addon-v1.md`.

`runSync()` performs one Bridge fetch for every mapped account, then syncs each
account in turn with every failure caught and recorded rather than propagated —
per-institution isolation is enforced at the `syncOne()` boundary. Adds
`compareBalances()` for the post-sync mismatch check, comparing decimal strings
by normalised value (never through float) and returning `null` when the
Wealthfolio figure is unavailable rather than inventing a comparison.

- `src/lib/sync/balance.ts` — decimal-string balance comparison
- `src/lib/sync/run.ts` — orchestration, fetch window, run summary, history append

Notes:
- The fetch window starts at the oldest per-account watermark minus a 7-day
  overlap, so a late-posting transaction is still seen; the recent-id window
  discards what was already pushed.
- Wealthfolio balances are read for the mismatch check inside its own `try` —
  the check is diagnostic, so a failure there degrades to "unavailable" instead
  of failing the run.
- `Account.balance` is a `number` in the SDK types, so the plan's
  `as unknown as { balance?: string }` cast was dropped in favour of the real
  typed field.

## Verification

- `pnpm test` → 73 passed (13 files), including the 10 new tests for this task
  (4 balance, 6 orchestration)
- `pnpm lint` (`tsc --noEmit`) → clean
- `pnpm build` → `dist/addon.js` emitted
- Isolation was verified negatively: temporarily replacing the per-account
  `catch` with a re-throw makes "isolates a per-account failure so the others
  still sync" fail, so the test proves the invariant rather than passing
  vacuously.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)