### PR TITLE
feat: add setup and account-mapping UI

### DIFF
--- a/src/addon.tsx
+++ b/src/addon.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AddonContext, AddonEnableFunction } from '@wealthfolio/addon-sdk';
-import { Card, CardContent } from '@wealthfolio/ui';
+import { ADDON_ID } from './lib/constants';
+import { SyncPage } from './pages/SyncPage';
 
 // The host owns a single React root per addon and mounts the route `component`
 // itself (`createElement(Component, { location })`) with no access to the addon
@@ -8,28 +9,13 @@ import { Card, CardContent } from '@wealthfolio/ui';
 // (Do NOT call createRoot yourself — the host manages the lifecycle.)
 let addonCtx: AddonContext | undefined;
 
-function AddonExample({ ctx }: { ctx: AddonContext }) {
-  return (
-    <div className="p-6">
-      <Card>
-        <CardContent className="p-6">
-          <h1 className="text-2xl font-semibold mb-2">simplefin-sync</h1>
-          <p className="text-muted-foreground">
-            Welcome to your new Wealthfolio addon! Start building amazing features.
-          </p>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
 // Route component. The sidebar entry + route are declared in manifest.json
 // (`contributes.routes` + `contributes.links`), so the host renders navigation
 // without booting the addon; this component only runs when the route is first
 // visited. The QueryClientProvider shares one cache across route navigations.
 const AddonRoute = () => (
   <QueryClientProvider client={addonCtx!.api.query.getClient() as QueryClient}>
-    <AddonExample ctx={addonCtx!} />
+    <SyncPage api={addonCtx!.api} />
   </QueryClientProvider>
 );
 
@@ -39,8 +25,8 @@ const enable: AddonEnableFunction = (ctx) => {
   // The route `id` MUST match `contributes.routes[].id` in manifest.json.
   // The host derives this root path from the manifest addon id.
   ctx.router.add({
-    id: 'simplefin-sync',
-    path: '/addons/simplefin-sync',
+    id: ADDON_ID,
+    path: `/addons/${ADDON_ID}`,
     component: AddonRoute,
   });
 

--- a/src/components/AccountMapTable.tsx
+++ b/src/components/AccountMapTable.tsx
@@ -1,0 +1,139 @@
+import type { Account, HostAPI } from '@wealthfolio/addon-sdk';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@wealthfolio/ui';
+import { useState } from 'react';
+import type { AccountMapping, SyncMode } from '../lib/storage/config';
+import type { SfAccount } from '../lib/simplefin/parse';
+import { CreateAccountDialog } from './CreateAccountDialog';
+import { nativeSelectClassName } from './nativeSelectStyle';
+
+const CREATE_OPTION = '__create__';
+
+export interface AccountMapTableProps {
+  api: HostAPI;
+  sfAccounts: SfAccount[];
+  wfAccounts: Account[];
+  mappings: AccountMapping[];
+  onChange: (mappings: AccountMapping[]) => void;
+  onAccountCreated: (account: Account) => void;
+}
+
+function defaultModeFor(sfAccount: SfAccount): SyncMode {
+  return sfAccount.holdings.length > 0 ? 'HOLDINGS' : 'CASH';
+}
+
+export function AccountMapTable({
+  api,
+  sfAccounts,
+  wfAccounts,
+  mappings,
+  onChange,
+  onAccountCreated,
+}: AccountMapTableProps) {
+  const [creatingFor, setCreatingFor] = useState<SfAccount | null>(null);
+
+  function mappingFor(sfAccountId: string) {
+    return mappings.find((m) => m.sfAccountId === sfAccountId);
+  }
+
+  function upsertMapping(sfAccount: SfAccount, wfAccountId: string) {
+    const existing = mappingFor(sfAccount.id);
+    const next: AccountMapping = {
+      sfAccountId: sfAccount.id,
+      wfAccountId,
+      mode: existing?.mode ?? defaultModeFor(sfAccount),
+      sfAccountName: sfAccount.name,
+      orgName: sfAccount.orgName,
+    };
+    onChange([...mappings.filter((m) => m.sfAccountId !== sfAccount.id), next]);
+  }
+
+  function handleSelectChange(sfAccount: SfAccount, value: string) {
+    if (value === CREATE_OPTION) {
+      setCreatingFor(sfAccount);
+      return;
+    }
+    if (value === '') {
+      onChange(mappings.filter((m) => m.sfAccountId !== sfAccount.id));
+      return;
+    }
+    upsertMapping(sfAccount, value);
+  }
+
+  function handleModeChange(sfAccount: SfAccount, mode: SyncMode) {
+    const existing = mappingFor(sfAccount.id);
+    if (!existing) return;
+    onChange(mappings.map((m) => (m.sfAccountId === sfAccount.id ? { ...m, mode } : m)));
+  }
+
+  function handleAccountCreated(sfAccount: SfAccount, account: Account) {
+    onAccountCreated(account);
+    upsertMapping(sfAccount, account.id);
+    setCreatingFor(null);
+  }
+
+  return (
+    <>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Institution</TableHead>
+            <TableHead>Account</TableHead>
+            <TableHead>Currency</TableHead>
+            <TableHead>Balance</TableHead>
+            <TableHead>Wealthfolio account</TableHead>
+            <TableHead>Sync mode</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sfAccounts.map((sfAccount) => {
+            const mapping = mappingFor(sfAccount.id);
+            return (
+              <TableRow key={sfAccount.id}>
+                <TableCell>{sfAccount.orgName}</TableCell>
+                <TableCell>{sfAccount.name}</TableCell>
+                <TableCell>{sfAccount.currency}</TableCell>
+                <TableCell>{sfAccount.balance}</TableCell>
+                <TableCell>
+                  <select
+                    aria-label={`Map ${sfAccount.name}`}
+                    className={nativeSelectClassName}
+                    value={mapping?.wfAccountId ?? ''}
+                    onChange={(e) => handleSelectChange(sfAccount, e.target.value)}
+                  >
+                    <option value="">Unmapped</option>
+                    {wfAccounts.map((wfAccount) => (
+                      <option key={wfAccount.id} value={wfAccount.id}>
+                        {wfAccount.name}
+                      </option>
+                    ))}
+                    <option value={CREATE_OPTION}>+ Create new account…</option>
+                  </select>
+                </TableCell>
+                <TableCell>
+                  <select
+                    aria-label={`Sync mode for ${sfAccount.name}`}
+                    className={nativeSelectClassName}
+                    value={mapping?.mode ?? defaultModeFor(sfAccount)}
+                    onChange={(e) => handleModeChange(sfAccount, e.target.value as SyncMode)}
+                    disabled={!mapping}
+                  >
+                    <option value="CASH">Cash</option>
+                    <option value="HOLDINGS">Holdings</option>
+                  </select>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+      {creatingFor && (
+        <CreateAccountDialog
+          api={api}
+          sfAccount={creatingFor}
+          onOpenChange={(open) => !open && setCreatingFor(null)}
+          onCreated={(account) => handleAccountCreated(creatingFor, account)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/CreateAccountDialog.test.tsx
+++ b/src/components/CreateAccountDialog.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockHost } from '../test/mockHost';
+import type { SfAccount } from '../lib/simplefin/parse';
+import { CreateAccountDialog } from './CreateAccountDialog';
+
+const CASH_ACCOUNT: SfAccount = {
+  id: 'ACT-1',
+  name: 'Checking',
+  currency: 'USD',
+  balance: '100.00',
+  balanceDate: 0,
+  orgName: 'Bank A',
+  transactions: [],
+  holdings: [],
+};
+
+const HOLDINGS_ACCOUNT: SfAccount = {
+  ...CASH_ACCOUNT,
+  id: 'ACT-2',
+  name: 'Brokerage',
+  holdings: [
+    {
+      symbol: 'VOO',
+      shares: '1',
+      currency: 'USD',
+      costBasis: null,
+      purchasePrice: null,
+      marketValue: '100',
+    },
+  ],
+};
+
+describe('CreateAccountDialog', () => {
+  it('prefills name, currency and type from a cash SimpleFIN account', async () => {
+    const host = createMockHost();
+    render(
+      <CreateAccountDialog
+        api={host.api}
+        sfAccount={CASH_ACCOUNT}
+        onOpenChange={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/name/i)).toHaveValue('Bank A Checking');
+    expect(screen.getByLabelText(/currency/i)).toHaveValue('USD');
+    expect(screen.getByLabelText(/account type/i)).toHaveValue('CASH');
+    expect(screen.getByLabelText(/tracking mode/i)).toHaveValue('TRANSACTIONS');
+  });
+
+  it('prefills SECURITIES/HOLDINGS when the SimpleFIN account reports holdings', async () => {
+    const host = createMockHost();
+    render(
+      <CreateAccountDialog
+        api={host.api}
+        sfAccount={HOLDINGS_ACCOUNT}
+        onOpenChange={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/account type/i)).toHaveValue('SECURITIES');
+    expect(screen.getByLabelText(/tracking mode/i)).toHaveValue('HOLDINGS');
+  });
+
+  it('surfaces a create failure without calling onCreated', async () => {
+    const host = createMockHost();
+    host.api.accounts.create = vi.fn(async () => {
+      throw new Error('account name already in use');
+    });
+    const onCreated = vi.fn();
+
+    render(
+      <CreateAccountDialog
+        api={host.api}
+        sfAccount={CASH_ACCOUNT}
+        onOpenChange={vi.fn()}
+        onCreated={onCreated}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(await screen.findByText(/account name already in use/i)).toBeInTheDocument();
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/CreateAccountDialog.tsx
+++ b/src/components/CreateAccountDialog.tsx
@@ -1,0 +1,154 @@
+import type { Account, HostAPI } from '@wealthfolio/addon-sdk';
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from '@wealthfolio/ui';
+import { useState } from 'react';
+import { KEY_PREFIX } from '../lib/constants';
+import type { SfAccount } from '../lib/simplefin/parse';
+import { nativeSelectClassName } from './nativeSelectStyle';
+
+export interface CreateAccountDialogProps {
+  api: HostAPI;
+  sfAccount: SfAccount;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (account: Account) => void;
+}
+
+type AccountTypeValue = Account['accountType'];
+type TrackingMode = Account['trackingMode'];
+
+// `AccountType` is declared in the SDK's .d.ts but the compiled package
+// never emits it as a runtime value, so the option list is spelled out here.
+const ACCOUNT_TYPES: AccountTypeValue[] = [
+  'SECURITIES',
+  'CASH',
+  'CREDIT_CARD',
+  'CRYPTOCURRENCY',
+];
+
+function deriveDraft(sfAccount: SfAccount) {
+  const hasHoldings = sfAccount.holdings.length > 0;
+  return {
+    name: `${sfAccount.orgName} ${sfAccount.name}`.trim(),
+    currency: sfAccount.currency,
+    accountType: (hasHoldings ? 'SECURITIES' : 'CASH') as AccountTypeValue,
+    trackingMode: (hasHoldings ? 'HOLDINGS' : 'TRANSACTIONS') as TrackingMode,
+  };
+}
+
+export function CreateAccountDialog({
+  api,
+  sfAccount,
+  onOpenChange,
+  onCreated,
+}: CreateAccountDialogProps) {
+  const [draft, setDraft] = useState(() => deriveDraft(sfAccount));
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  async function handleCreate() {
+    setError(null);
+    setCreating(true);
+    try {
+      const account = await api.accounts.create({
+        name: draft.name,
+        currency: draft.currency,
+        accountType: draft.accountType,
+        trackingMode: draft.trackingMode,
+        provider: KEY_PREFIX,
+        providerAccountId: sfAccount.id,
+      });
+      onCreated(account);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Wealthfolio account</DialogTitle>
+          <DialogDescription>
+            This account will be linked to {sfAccount.orgName} {sfAccount.name}.
+          </DialogDescription>
+        </DialogHeader>
+        {error && (
+          <Alert variant="destructive" role="alert">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="new-account-name">Name</Label>
+            <Input
+              id="new-account-name"
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              disabled={creating}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-account-currency">Currency</Label>
+            <Input
+              id="new-account-currency"
+              value={draft.currency}
+              onChange={(e) => setDraft({ ...draft, currency: e.target.value })}
+              disabled={creating}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-account-type">Account type</Label>
+            <select
+              id="new-account-type"
+              className={nativeSelectClassName}
+              value={draft.accountType}
+              onChange={(e) =>
+                setDraft({ ...draft, accountType: e.target.value as AccountTypeValue })
+              }
+              disabled={creating}
+            >
+              {ACCOUNT_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-account-tracking">Tracking mode</Label>
+            <select
+              id="new-account-tracking"
+              className={nativeSelectClassName}
+              value={draft.trackingMode}
+              onChange={(e) =>
+                setDraft({ ...draft, trackingMode: e.target.value as TrackingMode })
+              }
+              disabled={creating}
+            >
+              <option value="TRANSACTIONS">Transactions</option>
+              <option value="HOLDINGS">Holdings</option>
+            </select>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleCreate} disabled={creating || !draft.name.trim()}>
+            {creating ? 'Creating…' : 'Create'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/SetupCard.tsx
+++ b/src/components/SetupCard.tsx
@@ -1,0 +1,75 @@
+import type { HostAPI } from '@wealthfolio/addon-sdk';
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Label,
+  Textarea,
+} from '@wealthfolio/ui';
+import { useState } from 'react';
+import { AUTH_SECRET_KEY } from '../lib/simplefin/client';
+import { claimSetupToken } from '../lib/simplefin/claim';
+import { splitAccessUrl } from '../lib/simplefin/url';
+import { writeConfig } from '../lib/storage/config';
+
+export interface SetupCardProps {
+  api: HostAPI;
+  onConnected: () => void;
+}
+
+export function SetupCard({ api, onConnected }: SetupCardProps) {
+  const [token, setToken] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [connecting, setConnecting] = useState(false);
+
+  async function handleConnect() {
+    setError(null);
+    setConnecting(true);
+    try {
+      const accessUrl = await claimSetupToken(api.network, token);
+      const { baseUrl, basicAuthSecret } = splitAccessUrl(accessUrl);
+      await api.secrets.set(AUTH_SECRET_KEY, basicAuthSecret);
+      await writeConfig(api, { baseUrl, mappings: [] });
+      onConnected();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Connect to SimpleFIN</CardTitle>
+        <CardDescription>
+          Paste the setup token from your SimpleFIN Bridge dashboard to connect your accounts.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && (
+          <Alert variant="destructive" role="alert">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        <div className="space-y-2">
+          <Label htmlFor="setup-token">Setup token</Label>
+          <Textarea
+            id="setup-token"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            disabled={connecting}
+          />
+        </div>
+        <Button onClick={handleConnect} disabled={connecting || !token.trim()}>
+          {connecting ? 'Connecting…' : 'Connect'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/nativeSelectStyle.ts
+++ b/src/components/nativeSelectStyle.ts
@@ -1,0 +1,8 @@
+/**
+ * A native `<select>` is used in these forms instead of `@wealthfolio/ui`'s
+ * Radix-based `Select` because `userEvent.selectOptions` (the tests' way of
+ * choosing an option) does not work against Radix's listbox in jsdom. This
+ * class string matches the UI kit's input styling so it still looks native.
+ */
+export const nativeSelectClassName =
+  'border-input h-9 w-full rounded-md border bg-transparent px-3 text-sm';

--- a/src/pages/SyncPage.test.tsx
+++ b/src/pages/SyncPage.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockHost } from '../test/mockHost';
+import { SyncPage } from './SyncPage';
+
+describe('SyncPage', () => {
+  it('shows the setup card when no base URL is configured', async () => {
+    const host = createMockHost();
+    render(<SyncPage api={host.api} />);
+    expect(await screen.findByText(/connect to simplefin/i)).toBeInTheDocument();
+  });
+
+  it('claims a token and stores credentials in secrets, not storage', async () => {
+    const host = createMockHost();
+    host.respond(/\/claim\//, { body: 'https://alice:s3cret@bridge.simplefin.org/simplefin' });
+    host.respond(/\/accounts/, { body: JSON.stringify({ accounts: [], errors: [] }) });
+
+    render(<SyncPage api={host.api} />);
+    await userEvent.type(
+      await screen.findByLabelText(/setup token/i),
+      btoa('https://bridge.simplefin.org/simplefin/claim/DEMO'),
+    );
+    await userEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => expect(host.secrets.get('simplefin.auth')).toBe(btoa('alice:s3cret')));
+    // The credential must never reach durable storage.
+    expect([...host.storage.values()].join('')).not.toContain('s3cret');
+  });
+
+  it('surfaces a claim failure to the user instead of failing silently', async () => {
+    const host = createMockHost();
+    host.respond(/\/claim\//, { status: 403, body: 'Forbidden' });
+
+    render(<SyncPage api={host.api} />);
+    await userEvent.type(await screen.findByLabelText(/setup token/i), btoa('https://x/claim/D'));
+    await userEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    expect(await screen.findByText(/single-use/i)).toBeInTheDocument();
+  });
+
+  it('lists SimpleFIN accounts alongside Wealthfolio accounts once connected', async () => {
+    const host = createMockHost();
+    await host.api.storage.set(
+      'simplefin.config',
+      JSON.stringify({ baseUrl: 'https://bridge.simplefin.org/simplefin', mappings: [] }),
+    );
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        accounts: [{ id: 'ACT-1', name: 'Checking', currency: 'USD', balance: '1.00', 'balance-date': 1, org: { name: 'Bank A' } }],
+        errors: [],
+      }),
+    });
+    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', name: 'My Checking' }] as never);
+
+    render(<SyncPage api={host.api} />);
+    expect(await screen.findByText('Checking')).toBeInTheDocument();
+    expect(await screen.findByText('Bank A')).toBeInTheDocument();
+  });
+
+  it('persists a chosen mapping', async () => {
+    const host = createMockHost();
+    await host.api.storage.set(
+      'simplefin.config',
+      JSON.stringify({ baseUrl: 'https://bridge.simplefin.org/simplefin', mappings: [] }),
+    );
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        accounts: [{ id: 'ACT-1', name: 'Checking', currency: 'USD', balance: '1.00', 'balance-date': 1, org: { name: 'Bank A' } }],
+        errors: [],
+      }),
+    });
+    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', name: 'My Checking' }] as never);
+
+    render(<SyncPage api={host.api} />);
+    await userEvent.selectOptions(await screen.findByLabelText(/map checking/i), 'WF-1');
+
+    await waitFor(() => {
+      const config = JSON.parse(host.storage.get('simplefin.config') as string);
+      expect(config.mappings).toEqual([
+        expect.objectContaining({ sfAccountId: 'ACT-1', wfAccountId: 'WF-1' }),
+      ]);
+    });
+  });
+
+  it('creates a new Wealthfolio account on the spot and auto-maps it', async () => {
+    const host = createMockHost();
+    await host.api.storage.set(
+      'simplefin.config',
+      JSON.stringify({ baseUrl: 'https://bridge.simplefin.org/simplefin', mappings: [] }),
+    );
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        accounts: [{ id: 'ACT-1', name: 'Checking', currency: 'USD', balance: '1.00', 'balance-date': 1, org: { name: 'Bank A' } }],
+        errors: [],
+      }),
+    });
+    host.api.accounts.getAll = vi.fn(async () => [] as never);
+    host.api.accounts.create = vi.fn(async () => ({ id: 'WF-NEW', name: 'Bank A Checking' }) as never);
+
+    render(<SyncPage api={host.api} />);
+    await userEvent.selectOptions(await screen.findByLabelText(/map checking/i), '__create__');
+
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: /create/i }));
+
+    await waitFor(() => expect(host.api.accounts.create).toHaveBeenCalled());
+    await waitFor(() => {
+      const config = JSON.parse(host.storage.get('simplefin.config') as string);
+      expect(config.mappings).toEqual([
+        expect.objectContaining({ sfAccountId: 'ACT-1', wfAccountId: 'WF-NEW' }),
+      ]);
+    });
+  });
+
+  it('surfaces an error and keeps the previous state when persisting a mapping fails', async () => {
+    const host = createMockHost();
+    await host.api.storage.set(
+      'simplefin.config',
+      JSON.stringify({ baseUrl: 'https://bridge.simplefin.org/simplefin', mappings: [] }),
+    );
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        accounts: [{ id: 'ACT-1', name: 'Checking', currency: 'USD', balance: '1.00', 'balance-date': 1, org: { name: 'Bank A' } }],
+        errors: [],
+      }),
+    });
+    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', name: 'My Checking' }] as never);
+    host.api.storage.set = vi.fn(async () => {
+      throw new Error('storage unavailable');
+    });
+
+    render(<SyncPage api={host.api} />);
+    await userEvent.selectOptions(await screen.findByLabelText(/map checking/i), 'WF-1');
+
+    expect(await screen.findByText(/storage unavailable/i)).toBeInTheDocument();
+    expect(await screen.findByLabelText(/map checking/i)).toHaveValue('');
+  });
+
+  it('surfaces an error instead of staying blank when the initial config read fails', async () => {
+    const host = createMockHost();
+    host.api.storage.get = vi.fn(async () => {
+      throw new Error('storage unavailable');
+    });
+
+    render(<SyncPage api={host.api} />);
+
+    expect(await screen.findByText(/storage unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/SyncPage.tsx
+++ b/src/pages/SyncPage.tsx
@@ -1,0 +1,89 @@
+import type { Account, HostAPI } from '@wealthfolio/addon-sdk';
+import { Alert, AlertDescription } from '@wealthfolio/ui';
+import { useEffect, useState } from 'react';
+import { AccountMapTable } from '../components/AccountMapTable';
+import { SetupCard } from '../components/SetupCard';
+import { fetchAccounts } from '../lib/simplefin/client';
+import type { SfAccount } from '../lib/simplefin/parse';
+import { readConfig, writeConfig, type AccountMapping, type SyncConfig } from '../lib/storage/config';
+
+export interface SyncPageProps {
+  api: HostAPI;
+}
+
+export function SyncPage({ api }: SyncPageProps) {
+  const [config, setConfig] = useState<SyncConfig | null>(null);
+  const [sfAccounts, setSfAccounts] = useState<SfAccount[]>([]);
+  const [wfAccounts, setWfAccounts] = useState<Account[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadConfig() {
+    try {
+      setConfig(await readConfig(api));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  useEffect(() => {
+    loadConfig();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!config?.baseUrl) return;
+    const baseUrl = config.baseUrl;
+
+    setError(null);
+    Promise.all([fetchAccounts(api.network, baseUrl, {}), api.accounts.getAll()])
+      .then(([{ accounts }, wfAccountList]) => {
+        setSfAccounts(accounts);
+        setWfAccounts(wfAccountList);
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [config?.baseUrl]);
+
+  async function persistMappings(mappings: AccountMapping[]) {
+    if (!config) return;
+    const previous = config;
+    const next = { ...config, mappings };
+    setConfig(next);
+    try {
+      await writeConfig(api, next);
+    } catch (err) {
+      setConfig(previous);
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  if (!config) {
+    return error ? (
+      <Alert variant="destructive" role="alert">
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    ) : null;
+  }
+
+  if (!config.baseUrl) {
+    return <SetupCard api={api} onConnected={loadConfig} />;
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <AccountMapTable
+        api={api}
+        sfAccounts={sfAccounts}
+        wfAccounts={wfAccounts}
+        mappings={config.mappings}
+        onChange={persistMappings}
+        onAccountCreated={(account) => setWfAccounts((prev) => [...prev, account])}
+      />
+    </div>
+  );
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     include: ['src/**/*.test.{ts,tsx}'],
+    setupFiles: ['src/test/setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- Add `SetupCard`, `AccountMapTable`, `CreateAccountDialog` (the deferred create-account-on-the-spot flow), and `SyncPage`, wired into `src/addon.tsx` via the `component:` route pattern (never `createRoot`).
- Credentials go to `secrets` only; the credential-free base URL goes to `storage`, verified by a dedicated test.
- Wire `@testing-library/jest-dom/vitest` into `vitest.config.ts` (was missing, needed for `toBeInTheDocument()`).

## Test plan
- [x] `pnpm vitest run` — 15 files, 84 tests, all pass
- [x] `pnpm type-check` — clean
- [x] `pnpm build` — produces `dist/addon.js`
- [x] SyncPage tests confirm credentials never reach durable `storage`
- [x] Regression tests added for two error-handling bugs found in review (fire-and-forget config read/write)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)