### PR TITLE
fix: stop bundle hang and declare secrets.use permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -47,6 +47,7 @@
       "functions": [
         { "name": "set", "isDeclared": true, "isDetected": false },
         { "name": "get", "isDeclared": true, "isDetected": false },
+        { "name": "use", "isDeclared": true, "isDetected": false },
         { "name": "delete", "isDeclared": true, "isDetected": false }
       ],
       "purpose": "Store the SimpleFIN access credentials in the system keyring."

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,10 +42,5 @@ export default defineConfig({
     rollupOptions: {
       external: hostProvidedDependencies,
     },
-    watch: {
-      // Watch mode options for better hot reloading
-      include: ['src/**'],
-      exclude: ['node_modules/**', 'dist/**']
-    }
   },
 });


### PR DESCRIPTION
## Summary
- `vite.config.ts` had a static `build.watch` object that forced watch mode on for every `vite build` run (not just the `dev` script's explicit `--watch`), so `pnpm bundle` hung at the build step and never produced a zip. Removed the redundant block.
- `manifest.json` was missing `use` from the `secrets` permission functions. The addon-sdk's real schema is `["set", "get", "use", "delete"]` — `use` is what the host calls internally when `network.request()` resolves a `secretKey` (the brokered auth path `src/lib/simplefin/client.ts` relies on). Added it.

Closes #45

## Test plan
- [x] `pnpm bundle` completes and produces `dist/simplefin-wealthfolio-addon-1.0.0.zip`
- [x] Installed the zip via Install from File into a real self-hosted Wealthfolio 3.6.2+ instance — no longer throws "not allowed to call secrets.use", account mapping table renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)