### PR TITLE
feat: add sync trigger, results, bridge errors and history UI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -47,9 +47,10 @@
       "functions": [
         { "name": "set", "isDeclared": true, "isDetected": false },
         { "name": "get", "isDeclared": true, "isDetected": false },
+        { "name": "use", "isDeclared": true, "isDetected": false },
         { "name": "delete", "isDeclared": true, "isDetected": false }
       ],
-      "purpose": "Store the SimpleFIN access credentials in the system keyring."
+      "purpose": "Store the SimpleFIN access credentials in the system keyring, and let the host attach them to brokered SimpleFIN Bridge requests without exposing the plaintext to the addon."
     },
     {
       "category": "accounts",

--- a/src/components/BridgeErrorBanner.tsx
+++ b/src/components/BridgeErrorBanner.tsx
@@ -1,0 +1,27 @@
+import { Alert, AlertDescription, AlertTitle } from '@wealthfolio/ui';
+import type { SfBridgeError } from '../lib/simplefin/parse';
+
+export interface BridgeErrorBannerProps {
+  errors: SfBridgeError[];
+  dashboardUrl: string;
+}
+
+export function BridgeErrorBanner({ errors, dashboardUrl }: BridgeErrorBannerProps) {
+  if (errors.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {errors.map((error) => (
+        <Alert key={error.key} variant="warning" role="alert">
+          <AlertTitle>SimpleFIN Bridge error</AlertTitle>
+          <AlertDescription>
+            {error.msg}{' '}
+            <a href={dashboardUrl} target="_blank" rel="noreferrer">
+              Open SimpleFIN Bridge
+            </a>
+          </AlertDescription>
+        </Alert>
+      ))}
+    </div>
+  );
+}

--- a/src/components/CreateAccountDialog.test.tsx
+++ b/src/components/CreateAccountDialog.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { createMockHost } from '../test/mockHost';
+import { KEY_PREFIX } from '../lib/constants';
 import type { SfAccount } from '../lib/simplefin/parse';
 import { CreateAccountDialog } from './CreateAccountDialog';
 
@@ -63,6 +64,33 @@ describe('CreateAccountDialog', () => {
 
     expect(screen.getByLabelText(/account type/i)).toHaveValue('SECURITIES');
     expect(screen.getByLabelText(/tracking mode/i)).toHaveValue('HOLDINGS');
+  });
+
+  it('calls api.accounts.create with isDefault/isActive alongside the drafted fields', async () => {
+    const host = createMockHost();
+    host.api.accounts.create = vi.fn(async () => ({}) as never);
+    const onCreated = vi.fn();
+
+    render(
+      <CreateAccountDialog
+        api={host.api}
+        sfAccount={CASH_ACCOUNT}
+        onOpenChange={vi.fn()}
+        onCreated={onCreated}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    expect(host.api.accounts.create).toHaveBeenCalledWith({
+      name: 'Bank A Checking',
+      currency: 'USD',
+      accountType: 'CASH',
+      trackingMode: 'TRANSACTIONS',
+      provider: KEY_PREFIX,
+      providerAccountId: 'ACT-1',
+      isDefault: false,
+      isActive: true,
+    });
   });
 
   it('surfaces a create failure without calling onCreated', async () => {

--- a/src/components/CreateAccountDialog.tsx
+++ b/src/components/CreateAccountDialog.tsx
@@ -67,6 +67,11 @@ export function CreateAccountDialog({
         trackingMode: draft.trackingMode,
         provider: KEY_PREFIX,
         providerAccountId: sfAccount.id,
+        // The backend's create endpoint requires these even though they're
+        // normally server-computed; the addon-sdk's Account type doesn't
+        // surface that its `create()` payload diverges from its response shape.
+        isDefault: false,
+        isActive: true,
       });
       onCreated(account);
     } catch (err) {

--- a/src/components/HistoryList.tsx
+++ b/src/components/HistoryList.tsx
@@ -1,0 +1,46 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@wealthfolio/ui';
+import type { SyncRun } from '../lib/storage/history';
+
+export interface HistoryListProps {
+  /** Newest-first, as returned by `readHistory` — not re-sorted here. */
+  runs: SyncRun[];
+}
+
+/** null only when no account in the run has a computed imported count. */
+function totalImported(run: SyncRun): number | null {
+  const counted = run.accounts.filter((a) => a.imported !== null);
+  if (counted.length === 0) return null;
+  return counted.reduce((sum, a) => sum + (a.imported as number), 0);
+}
+
+function failureCount(run: SyncRun): number {
+  return run.accounts.filter((a) => a.error !== null).length;
+}
+
+export function HistoryList({ runs }: HistoryListProps) {
+  if (runs.length === 0) return null;
+
+  return (
+    <Table aria-label="Sync history">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Run</TableHead>
+          <TableHead>Imported</TableHead>
+          <TableHead>Failures</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {runs.map((run) => {
+          const imported = totalImported(run);
+          return (
+            <TableRow key={run.startedAt}>
+              <TableCell>{new Date(run.startedAt).toLocaleString()}</TableCell>
+              <TableCell>{imported === null ? '—' : imported}</TableCell>
+              <TableCell>{failureCount(run)}</TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/SyncSummary.tsx
+++ b/src/components/SyncSummary.tsx
@@ -1,0 +1,56 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@wealthfolio/ui';
+import type { AccountRunResult, SyncRun } from '../lib/storage/history';
+
+export interface SyncSummaryProps {
+  run: SyncRun;
+}
+
+function cell(value: number | null): string {
+  return value === null ? '—' : String(value);
+}
+
+/** null unless every count that feeds it was actually computed. */
+function totalFor(result: AccountRunResult): number | null {
+  const { imported, skipped, duplicates } = result;
+  if (imported === null || skipped === null || duplicates === null) return null;
+  return imported + skipped + duplicates;
+}
+
+export function SyncSummary({ run }: SyncSummaryProps) {
+  return (
+    <Table aria-label="Sync results">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Account</TableHead>
+          <TableHead>Imported</TableHead>
+          <TableHead>Skipped</TableHead>
+          <TableHead>Duplicates</TableHead>
+          <TableHead>Total</TableHead>
+          <TableHead>Balance</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {run.accounts.map((result) => (
+          <TableRow key={result.sfAccountId}>
+            <TableCell>{result.sfAccountName}</TableCell>
+            {result.error ? (
+              <TableCell colSpan={5}>Failed: {result.error}</TableCell>
+            ) : (
+              <>
+                <TableCell>{cell(result.imported)}</TableCell>
+                <TableCell>{cell(result.skipped)}</TableCell>
+                <TableCell>{cell(result.duplicates)}</TableCell>
+                <TableCell>{cell(totalFor(result))}</TableCell>
+                <TableCell>
+                  {result.balanceMismatch
+                    ? `SimpleFIN ${result.balanceMismatch.simplefin} vs Wealthfolio ${result.balanceMismatch.wealthfolio}`
+                    : '—'}
+                </TableCell>
+              </>
+            )}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/pages/SyncPage.sync.test.tsx
+++ b/src/pages/SyncPage.sync.test.tsx
@@ -1,0 +1,262 @@
+import type { ActivityImport } from '@wealthfolio/addon-sdk';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockHost } from '../test/mockHost';
+import { appendRun } from '../lib/storage/history';
+import { SyncPage } from './SyncPage';
+
+function seedConfig(host: ReturnType<typeof createMockHost>, mappings: unknown[]) {
+  host.storage.set(
+    'simplefin.config',
+    JSON.stringify({ baseUrl: 'https://bridge.simplefin.org/simplefin', mappings }),
+  );
+}
+
+const CHECKING_MAPPING = {
+  sfAccountId: 'ACT-1',
+  wfAccountId: 'WF-1',
+  mode: 'CASH',
+  sfAccountName: 'Checking',
+  orgName: 'Bank A',
+};
+
+describe('SyncPage sync trigger', () => {
+  it('calls runSync and renders per-account imported counts', async () => {
+    const host = createMockHost();
+    seedConfig(host, [CHECKING_MAPPING]);
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        accounts: [
+          {
+            id: 'ACT-1',
+            name: 'Checking',
+            currency: 'USD',
+            balance: '100.00',
+            'balance-date': 1700000000,
+            org: { name: 'Bank A' },
+            transactions: [
+              { id: 'TXN-1', posted: 1700000000, amount: '-12.34', description: 'Coffee', payee: 'Cafe', memo: null, pending: false },
+            ],
+          },
+        ],
+        errors: [],
+      }),
+    });
+    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', name: 'My Checking', balance: 100 }] as never);
+    host.api.activities.checkImport = vi.fn(async (rows: ActivityImport[]) => rows.map((r) => ({ ...r, isValid: true })) as never);
+    host.api.activities.import = vi.fn(
+      async () =>
+        ({ activities: [], importRunId: 'run1', summary: { total: 1, imported: 1, skipped: 0, duplicates: 0, assetsCreated: 0, success: true } }) as never,
+    );
+
+    render(<SyncPage api={host.api} />);
+    await screen.findByText('Checking');
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }));
+
+    const resultsTable = await screen.findByRole('table', { name: /sync results/i });
+    const row = within(resultsTable).getByText('Checking').closest('tr');
+    expect(row).not.toBeNull();
+    const cells = within(row as HTMLElement)
+      .getAllByRole('cell')
+      .map((c) => c.textContent);
+    expect(cells).toEqual(['Checking', '1', '0', '0', '1', '—']);
+  });
+
+  it('renders a per-account error as failed while other accounts show success', async () => {
+    const host = createMockHost();
+    const secondMapping = {
+      sfAccountId: 'ACT-2',
+      wfAccountId: 'WF-2',
+      mode: 'CASH',
+      sfAccountName: 'Savings',
+      orgName: 'Bank B',
+    };
+    seedConfig(host, [CHECKING_MAPPING, secondMapping]);
+    host.respond(/\/accounts/, {
+      // ACT-2 is absent from the Bridge response, so its sync fails automatically.
+      body: JSON.stringify({
+        accounts: [
+          {
+            id: 'ACT-1',
+            name: 'Checking',
+            currency: 'USD',
+            balance: '100.00',
+            'balance-date': 1700000000,
+            org: { name: 'Bank A' },
+            transactions: [],
+          },
+        ],
+        errors: [],
+      }),
+    });
+    host.api.accounts.getAll = vi.fn(async () => [
+      { id: 'WF-1', name: 'My Checking', balance: 100 },
+      { id: 'WF-2', name: 'My Savings', balance: 0 },
+    ] as never);
+
+    render(<SyncPage api={host.api} />);
+    await screen.findByText('Checking');
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }));
+
+    const resultsTable = await screen.findByRole('table', { name: /sync results/i });
+    expect(await within(resultsTable).findByText(/was not returned by the bridge/i)).toBeInTheDocument();
+
+    const okRow = within(resultsTable).getByText('Checking').closest('tr');
+    const okCells = within(okRow as HTMLElement)
+      .getAllByRole('cell')
+      .map((c) => c.textContent);
+    expect(okCells).toEqual(['Checking', '0', '0', '0', '0', '—']);
+  });
+
+  it('renders a bridge error banner naming the institution with a link to the credential-free dashboard host', async () => {
+    const host = createMockHost();
+    seedConfig(host, []);
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        accounts: [],
+        errlist: [{ code: 'x', msg: 'Bank of Example connection has expired', conn_id: 'conn1' }],
+      }),
+    });
+
+    render(<SyncPage api={host.api} />);
+    await userEvent.click(await screen.findByRole('button', { name: /sync now/i }));
+
+    expect(await screen.findByText(/bank of example connection has expired/i)).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /open simplefin bridge/i });
+    expect(link).toHaveAttribute('href', 'https://bridge.simplefin.org');
+  });
+
+  it('renders both figures for an account with a balance mismatch', async () => {
+    const host = createMockHost();
+    seedConfig(host, [CHECKING_MAPPING]);
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        accounts: [
+          {
+            id: 'ACT-1',
+            name: 'Checking',
+            currency: 'USD',
+            balance: '150.00',
+            'balance-date': 1700000000,
+            org: { name: 'Bank A' },
+            transactions: [],
+          },
+        ],
+        errors: [],
+      }),
+    });
+    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', name: 'My Checking', balance: 100 }] as never);
+
+    render(<SyncPage api={host.api} />);
+    await screen.findByText('Checking');
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }));
+
+    const resultsTable = await screen.findByRole('table', { name: /sync results/i });
+    expect(await within(resultsTable).findByText(/simplefin 150\.00 vs wealthfolio 100/i)).toBeInTheDocument();
+  });
+
+  it('disables the sync button while a run is in flight', async () => {
+    const host = createMockHost();
+    seedConfig(host, [CHECKING_MAPPING]);
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        accounts: [
+          { id: 'ACT-1', name: 'Checking', currency: 'USD', balance: '100.00', 'balance-date': 1700000000, org: { name: 'Bank A' }, transactions: [] },
+        ],
+        errors: [],
+      }),
+    });
+    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', name: 'My Checking', balance: 100 }] as never);
+
+    render(<SyncPage api={host.api} />);
+    await screen.findByText('Checking');
+
+    let resolveRequest!: (value: { status: number; headers: Record<string, string>; body: string }) => void;
+    const pending = new Promise<{ status: number; headers: Record<string, string>; body: string }>((resolve) => {
+      resolveRequest = resolve;
+    });
+    host.api.network.request = vi.fn(() => pending) as never;
+
+    const button = screen.getByRole('button', { name: /sync now/i });
+    await userEvent.click(button);
+
+    expect(button).toBeDisabled();
+
+    resolveRequest({ status: 200, headers: {}, body: JSON.stringify({ accounts: [], errors: [] }) });
+
+    await waitFor(() => expect(button).toBeEnabled());
+  });
+
+  it('renders history newest-first after a completed run', async () => {
+    const host = createMockHost();
+    seedConfig(host, [CHECKING_MAPPING]);
+    await appendRun(host.api, {
+      startedAt: '2026-01-01T00:00:00.000Z',
+      finishedAt: '2026-01-01T00:00:01.000Z',
+      accounts: [
+        {
+          sfAccountId: 'ACT-OLD',
+          sfAccountName: 'Old',
+          orgName: 'Old Bank',
+          wfAccountId: 'WF-OLD',
+          mode: 'CASH',
+          imported: 3,
+          skipped: 0,
+          duplicates: 0,
+          error: null,
+          balanceMismatch: null,
+        },
+      ],
+      bridgeErrors: [],
+    });
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        accounts: [
+          {
+            id: 'ACT-1',
+            name: 'Checking',
+            currency: 'USD',
+            balance: '100.00',
+            'balance-date': 1700000000,
+            org: { name: 'Bank A' },
+            transactions: [{ id: 'TXN-1', posted: 1700000000, amount: '-1.00', description: 'x', payee: null, memo: null, pending: false }],
+          },
+        ],
+        errors: [],
+      }),
+    });
+    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', name: 'My Checking', balance: 100 }] as never);
+    host.api.activities.checkImport = vi.fn(async (rows: ActivityImport[]) => rows.map((r) => ({ ...r, isValid: true })) as never);
+    host.api.activities.import = vi.fn(
+      async () =>
+        ({ activities: [], importRunId: 'run2', summary: { total: 1, imported: 2, skipped: 0, duplicates: 0, assetsCreated: 0, success: true } }) as never,
+    );
+
+    render(<SyncPage api={host.api} />);
+    await screen.findByText('Checking');
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }));
+
+    const historyTable = await screen.findByRole('table', { name: /sync history/i });
+    const rows = within(historyTable).getAllByRole('row').slice(1); // drop header row
+    expect(rows).toHaveLength(2);
+    expect(within(rows[0]).getAllByRole('cell')[1].textContent).toBe('2');
+    expect(within(rows[1]).getAllByRole('cell')[1].textContent).toBe('3');
+  });
+
+  it('surfaces a thrown runSync as a visible error and re-enables the button', async () => {
+    const host = createMockHost();
+    seedConfig(host, []);
+    host.respond(/\/accounts/, { body: JSON.stringify({ accounts: [], errors: [] }) });
+    host.api.storage.set = vi.fn(async () => {
+      throw new Error('history storage unavailable');
+    });
+
+    render(<SyncPage api={host.api} />);
+    const button = await screen.findByRole('button', { name: /sync now/i });
+    await userEvent.click(button);
+
+    expect(await screen.findByText(/history storage unavailable/i)).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /sync now/i })).toBeEnabled();
+  });
+});

--- a/src/pages/SyncPage.tsx
+++ b/src/pages/SyncPage.tsx
@@ -1,11 +1,17 @@
 import type { Account, HostAPI } from '@wealthfolio/addon-sdk';
-import { Alert, AlertDescription } from '@wealthfolio/ui';
+import { Alert, AlertDescription, Button } from '@wealthfolio/ui';
 import { useEffect, useState } from 'react';
 import { AccountMapTable } from '../components/AccountMapTable';
+import { BridgeErrorBanner } from '../components/BridgeErrorBanner';
+import { HistoryList } from '../components/HistoryList';
 import { SetupCard } from '../components/SetupCard';
+import { SyncSummary } from '../components/SyncSummary';
 import { fetchAccounts } from '../lib/simplefin/client';
 import type { SfAccount } from '../lib/simplefin/parse';
+import { bridgeDashboardUrl } from '../lib/simplefin/url';
 import { readConfig, writeConfig, type AccountMapping, type SyncConfig } from '../lib/storage/config';
+import { readHistory, type SyncRun } from '../lib/storage/history';
+import { runSync } from '../lib/sync/run';
 
 export interface SyncPageProps {
   api: HostAPI;
@@ -16,6 +22,10 @@ export function SyncPage({ api }: SyncPageProps) {
   const [sfAccounts, setSfAccounts] = useState<SfAccount[]>([]);
   const [wfAccounts, setWfAccounts] = useState<Account[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [syncError, setSyncError] = useState<string | null>(null);
+  const [lastRun, setLastRun] = useState<SyncRun | null>(null);
+  const [history, setHistory] = useState<SyncRun[]>([]);
 
   async function loadConfig() {
     try {
@@ -35,14 +45,32 @@ export function SyncPage({ api }: SyncPageProps) {
     const baseUrl = config.baseUrl;
 
     setError(null);
-    Promise.all([fetchAccounts(api.network, baseUrl, {}), api.accounts.getAll()])
-      .then(([{ accounts }, wfAccountList]) => {
+    Promise.all([fetchAccounts(api.network, baseUrl, {}), api.accounts.getAll(), readHistory(api)])
+      .then(([{ accounts }, wfAccountList, historyList]) => {
         setSfAccounts(accounts);
         setWfAccounts(wfAccountList);
+        setHistory(historyList);
       })
       .catch((err) => setError(err instanceof Error ? err.message : String(err)));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [config?.baseUrl]);
+
+  async function handleSync() {
+    if (!config?.baseUrl) return;
+    setSyncing(true);
+    setSyncError(null);
+    try {
+      const run = await runSync(api, config);
+      setLastRun(run);
+      setHistory(await readHistory(api));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      api.logger.error(`[simplefin] sync failed: ${message}`);
+      setSyncError(message);
+    } finally {
+      setSyncing(false);
+    }
+  }
 
   async function persistMappings(mappings: AccountMapping[]) {
     if (!config) return;
@@ -84,6 +112,23 @@ export function SyncPage({ api }: SyncPageProps) {
         onChange={persistMappings}
         onAccountCreated={(account) => setWfAccounts((prev) => [...prev, account])}
       />
+      <div className="space-y-2">
+        <Button onClick={handleSync} disabled={syncing}>
+          {syncing ? 'Syncing…' : 'Sync now'}
+        </Button>
+        {syncError && (
+          <Alert variant="destructive" role="alert">
+            <AlertDescription>{syncError}</AlertDescription>
+          </Alert>
+        )}
+      </div>
+      {lastRun && (
+        <>
+          <BridgeErrorBanner errors={lastRun.bridgeErrors} dashboardUrl={bridgeDashboardUrl(config.baseUrl)} />
+          <SyncSummary run={lastRun} />
+        </>
+      )}
+      <HistoryList runs={history} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add `SyncSummary`, `BridgeErrorBanner`, and `HistoryList`, wired into `SyncPage` behind a "Sync now" button — columns ordered account → imported → skipped → duplicates → total → balance reconciliation so reading order matches the arithmetic. Failed accounts render inline; uncomputed counts render `—`, never `0`.
- Two runtime bugs found and fixed during live E2E verification against a disposable, dockerized self-hosted Wealthfolio instance (both required for the addon to function at all, both outside this task's own diff):
  - `manifest.json` was missing the `secrets.use` permission the SDK requires to resolve stored credentials host-side for brokered network requests — every account fetch after claiming a token failed at runtime. (Note: a fix for the same gap landed concurrently on `dev` via #46; this branch merges `dev` to pick that up, which also fixed a `vite.config.ts` bug that made `pnpm build` hang forever.)
  - `CreateAccountDialog`'s `accounts.create()` call omitted `isDefault`/`isActive`, which the host's create endpoint actually requires despite the SDK's `Account` type documenting them as server-computed — every "Create new account" attempt 422'd. Confirmed the exact fix via direct `curl` against the running instance's API, then added a regression test since the SDK's `create(account: unknown)` signature gives TypeScript no protection against this being silently reintroduced.

## Test plan
- [x] `pnpm test` — 16 files, 92 tests, all pass
- [x] `pnpm type-check` — clean
- [x] `pnpm build` — produces `dist/addon.js`
- [x] Task-level review: spec ✅ compliant, quality Approved, zero Critical/Important findings
- [x] Final whole-branch review (opus): one Important finding (missing regression test) fixed and re-reviewed clean; minor findings (stale README/CHANGELOG, over-broad `secrets` permissions, a stale-results UX edge case) triaged as safe follow-ups
- [x] Live E2E against a real self-hosted Wealthfolio instance (Docker): sidebar entry appears, claiming a real SimpleFIN setup token stores credentials and shows the mapping table, buttons respond correctly (no `createRoot` regression), creating a Wealthfolio account on the spot succeeds
- [ ] **Second consecutive sync imports zero** — the plan's own "single most important behaviour," **not confirmed live**. The one account mapped during E2E testing had no postable transactions in its fetch window (SimpleFIN Activities showed zero imports across three sync attempts), so a real "N imported → 0 imported" transition was never observed; mapping a second account to test this was blocked by a browser-automation limitation with native `<select>` elements inside the addon's sandboxed iframe, not a code issue. The duplicate-suppression logic itself has full unit coverage (`src/lib/sync/run.test.ts`, `src/lib/storage/watermark.test.ts`) against mocked Bridge responses — what remains unverified is real-world SimpleFIN transaction-id stability across fetches, which only a live run can confirm. Per-institution failure isolation limits the blast radius to one account if this assumption ever turns out wrong.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)