### PR TITLE
feat: redesign sync UI, fix cash import symbol field, backfill opening balance

### DIFF
--- a/src/components/AccountMapTable.test.tsx
+++ b/src/components/AccountMapTable.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockHost } from '../test/mockHost';
+import type { SfAccount } from '../lib/simplefin/parse';
+import { AccountMapTable } from './AccountMapTable';
+
+function sfAccount(overrides: Partial<SfAccount>): SfAccount {
+  return {
+    id: 'ACT-1',
+    name: 'Checking',
+    currency: 'USD',
+    balance: '100.00',
+    balanceDate: 0,
+    orgName: 'Bank A',
+    transactions: [],
+    holdings: [],
+    ...overrides,
+  };
+}
+
+const CHECKING = sfAccount({ id: 'ACT-1', name: 'Checking', orgName: 'Bank A' });
+const SAVINGS = sfAccount({ id: 'ACT-2', name: 'Savings', orgName: 'Bank A' });
+const BROKERAGE = sfAccount({ id: 'ACT-3', name: 'Brokerage', orgName: 'Bank B' });
+
+describe('AccountMapTable', () => {
+  it('groups accounts under their institution with an account count', async () => {
+    const host = createMockHost();
+    render(
+      <AccountMapTable
+        api={host.api}
+        sfAccounts={[CHECKING, SAVINGS, BROKERAGE]}
+        wfAccounts={[]}
+        mappings={[]}
+        onChange={vi.fn()}
+        onAccountCreated={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /bank a.*\(2\)/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /bank b.*\(1\)/i })).toBeInTheDocument();
+    expect(screen.getByText('Checking')).toBeInTheDocument();
+    expect(screen.getByText('Savings')).toBeInTheDocument();
+    expect(screen.getByText('Brokerage')).toBeInTheDocument();
+  });
+
+  it('collapses and re-expands an institution group on click', async () => {
+    const host = createMockHost();
+    render(
+      <AccountMapTable
+        api={host.api}
+        sfAccounts={[CHECKING, SAVINGS, BROKERAGE]}
+        wfAccounts={[]}
+        mappings={[]}
+        onChange={vi.fn()}
+        onAccountCreated={vi.fn()}
+      />,
+    );
+
+    const bankAToggle = screen.getByRole('button', { name: /bank a.*\(2\)/i });
+    expect(bankAToggle).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.click(bankAToggle);
+    expect(bankAToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Checking')).not.toBeInTheDocument();
+    expect(screen.queryByText('Savings')).not.toBeInTheDocument();
+    // Bank B is a separate group and stays expanded.
+    expect(screen.getByText('Brokerage')).toBeInTheDocument();
+
+    await userEvent.click(bankAToggle);
+    expect(bankAToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Checking')).toBeInTheDocument();
+    expect(screen.getByText('Savings')).toBeInTheDocument();
+  });
+});

--- a/src/components/AccountMapTable.tsx
+++ b/src/components/AccountMapTable.tsx
@@ -1,12 +1,26 @@
 import type { Account, HostAPI } from '@wealthfolio/addon-sdk';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@wealthfolio/ui';
-import { useState } from 'react';
+import { cn, formatAmount, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@wealthfolio/ui';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { Fragment, useState } from 'react';
 import type { AccountMapping, SyncMode } from '../lib/storage/config';
 import type { SfAccount } from '../lib/simplefin/parse';
 import { CreateAccountDialog } from './CreateAccountDialog';
 import { nativeSelectClassName } from './nativeSelectStyle';
+import { compactCellClassName, compactHeadClassName } from './tableStyle';
 
 const CREATE_OPTION = '__create__';
+const COLUMN_COUNT = 5;
+
+/** Groups accounts by institution, preserving first-seen order. */
+function groupByInstitution(sfAccounts: SfAccount[]): [string, SfAccount[]][] {
+  const groups = new Map<string, SfAccount[]>();
+  for (const sfAccount of sfAccounts) {
+    const group = groups.get(sfAccount.orgName) ?? [];
+    group.push(sfAccount);
+    groups.set(sfAccount.orgName, group);
+  }
+  return [...groups.entries()];
+}
 
 export interface AccountMapTableProps {
   api: HostAPI;
@@ -30,6 +44,19 @@ export function AccountMapTable({
   onAccountCreated,
 }: AccountMapTableProps) {
   const [creatingFor, setCreatingFor] = useState<SfAccount | null>(null);
+  const [collapsedOrgs, setCollapsedOrgs] = useState<Set<string>>(new Set());
+
+  function toggleOrg(orgName: string) {
+    setCollapsedOrgs((prev) => {
+      const next = new Set(prev);
+      if (next.has(orgName)) {
+        next.delete(orgName);
+      } else {
+        next.add(orgName);
+      }
+      return next;
+    });
+  }
 
   function mappingFor(sfAccountId: string) {
     return mappings.find((m) => m.sfAccountId === sfAccountId);
@@ -76,52 +103,78 @@ export function AccountMapTable({
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Institution</TableHead>
-            <TableHead>Account</TableHead>
-            <TableHead>Currency</TableHead>
-            <TableHead>Balance</TableHead>
-            <TableHead>Wealthfolio account</TableHead>
-            <TableHead>Sync mode</TableHead>
+            <TableHead className={compactHeadClassName}>Account</TableHead>
+            <TableHead className={compactHeadClassName}>Currency</TableHead>
+            <TableHead className={cn(compactHeadClassName, 'text-right')}>Balance</TableHead>
+            <TableHead className={compactHeadClassName}>Wealthfolio account</TableHead>
+            <TableHead className={compactHeadClassName}>Sync mode</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
-          {sfAccounts.map((sfAccount) => {
-            const mapping = mappingFor(sfAccount.id);
+          {groupByInstitution(sfAccounts).map(([orgName, accounts]) => {
+            const collapsed = collapsedOrgs.has(orgName);
             return (
-              <TableRow key={sfAccount.id}>
-                <TableCell>{sfAccount.orgName}</TableCell>
-                <TableCell>{sfAccount.name}</TableCell>
-                <TableCell>{sfAccount.currency}</TableCell>
-                <TableCell>{sfAccount.balance}</TableCell>
-                <TableCell>
-                  <select
-                    aria-label={`Map ${sfAccount.name}`}
-                    className={nativeSelectClassName}
-                    value={mapping?.wfAccountId ?? ''}
-                    onChange={(e) => handleSelectChange(sfAccount, e.target.value)}
-                  >
-                    <option value="">Unmapped</option>
-                    {wfAccounts.map((wfAccount) => (
-                      <option key={wfAccount.id} value={wfAccount.id}>
-                        {wfAccount.name}
-                      </option>
-                    ))}
-                    <option value={CREATE_OPTION}>+ Create new account…</option>
-                  </select>
-                </TableCell>
-                <TableCell>
-                  <select
-                    aria-label={`Sync mode for ${sfAccount.name}`}
-                    className={nativeSelectClassName}
-                    value={mapping?.mode ?? defaultModeFor(sfAccount)}
-                    onChange={(e) => handleModeChange(sfAccount, e.target.value as SyncMode)}
-                    disabled={!mapping}
-                  >
-                    <option value="CASH">Cash</option>
-                    <option value="HOLDINGS">Holdings</option>
-                  </select>
-                </TableCell>
-              </TableRow>
+              <Fragment key={orgName}>
+                <TableRow>
+                  <TableCell className={compactCellClassName} colSpan={COLUMN_COUNT}>
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-2 text-left font-medium"
+                      aria-expanded={!collapsed}
+                      onClick={() => toggleOrg(orgName)}
+                    >
+                      {collapsed ? (
+                        <ChevronRight className="h-4 w-4 shrink-0" />
+                      ) : (
+                        <ChevronDown className="h-4 w-4 shrink-0" />
+                      )}
+                      {orgName}
+                      <span className="text-muted-foreground font-normal">({accounts.length})</span>
+                    </button>
+                  </TableCell>
+                </TableRow>
+                {!collapsed &&
+                  accounts.map((sfAccount) => {
+                    const mapping = mappingFor(sfAccount.id);
+                    return (
+                      <TableRow key={sfAccount.id}>
+                        <TableCell className={cn(compactCellClassName, 'pl-9')}>{sfAccount.name}</TableCell>
+                        <TableCell className={compactCellClassName}>{sfAccount.currency}</TableCell>
+                        <TableCell className={cn(compactCellClassName, 'text-right tabular-nums')}>
+                          {formatAmount(sfAccount.balance, sfAccount.currency)}
+                        </TableCell>
+                        <TableCell className={compactCellClassName}>
+                          <select
+                            aria-label={`Map ${sfAccount.name}`}
+                            className={nativeSelectClassName}
+                            value={mapping?.wfAccountId ?? ''}
+                            onChange={(e) => handleSelectChange(sfAccount, e.target.value)}
+                          >
+                            <option value="">Unmapped</option>
+                            {wfAccounts.map((wfAccount) => (
+                              <option key={wfAccount.id} value={wfAccount.id}>
+                                {wfAccount.name}
+                              </option>
+                            ))}
+                            <option value={CREATE_OPTION}>+ Create new account…</option>
+                          </select>
+                        </TableCell>
+                        <TableCell className={compactCellClassName}>
+                          <select
+                            aria-label={`Sync mode for ${sfAccount.name}`}
+                            className={nativeSelectClassName}
+                            value={mapping?.mode ?? defaultModeFor(sfAccount)}
+                            onChange={(e) => handleModeChange(sfAccount, e.target.value as SyncMode)}
+                            disabled={!mapping}
+                          >
+                            <option value="CASH">Cash</option>
+                            <option value="HOLDINGS">Holdings</option>
+                          </select>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+              </Fragment>
             );
           })}
         </TableBody>

--- a/src/components/HistoryList.tsx
+++ b/src/components/HistoryList.tsx
@@ -1,5 +1,6 @@
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@wealthfolio/ui';
+import { cn, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@wealthfolio/ui';
 import type { SyncRun } from '../lib/storage/history';
+import { compactCellClassName, compactHeadClassName } from './tableStyle';
 
 export interface HistoryListProps {
   /** Newest-first, as returned by `readHistory` — not re-sorted here. */
@@ -24,9 +25,9 @@ export function HistoryList({ runs }: HistoryListProps) {
     <Table aria-label="Sync history">
       <TableHeader>
         <TableRow>
-          <TableHead>Run</TableHead>
-          <TableHead>Imported</TableHead>
-          <TableHead>Failures</TableHead>
+          <TableHead className={compactHeadClassName}>Run</TableHead>
+          <TableHead className={cn(compactHeadClassName, 'text-right')}>Imported</TableHead>
+          <TableHead className={cn(compactHeadClassName, 'text-right')}>Failures</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -34,9 +35,13 @@ export function HistoryList({ runs }: HistoryListProps) {
           const imported = totalImported(run);
           return (
             <TableRow key={run.startedAt}>
-              <TableCell>{new Date(run.startedAt).toLocaleString()}</TableCell>
-              <TableCell>{imported === null ? '—' : imported}</TableCell>
-              <TableCell>{failureCount(run)}</TableCell>
+              <TableCell className={compactCellClassName}>{new Date(run.startedAt).toLocaleString()}</TableCell>
+              <TableCell className={cn(compactCellClassName, 'text-right tabular-nums')}>
+                {imported === null ? '—' : imported}
+              </TableCell>
+              <TableCell className={cn(compactCellClassName, 'text-right tabular-nums')}>
+                {failureCount(run)}
+              </TableCell>
             </TableRow>
           );
         })}

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockHost } from '../test/mockHost';
+import { AUTH_SECRET_KEY } from '../lib/simplefin/client';
+import { DEFAULT_LOOKBACK_DAYS } from '../lib/storage/config';
+import { SettingsPanel } from './SettingsPanel';
+
+const BASE_URL = 'https://bridge.simplefin.org/simplefin';
+
+function renderPanel(overrides: Partial<Parameters<typeof SettingsPanel>[0]> = {}) {
+  const host = createMockHost();
+  const onDisconnected = vi.fn();
+  const onLookbackDaysChange = vi.fn();
+  render(
+    <SettingsPanel
+      api={host.api}
+      baseUrl={BASE_URL}
+      lookbackDays={DEFAULT_LOOKBACK_DAYS}
+      onLookbackDaysChange={onLookbackDaysChange}
+      onDisconnected={onDisconnected}
+      {...overrides}
+    />,
+  );
+  return { host, onDisconnected, onLookbackDaysChange };
+}
+
+describe('SettingsPanel', () => {
+  it('shows the connected Bridge URL with the path masked', () => {
+    renderPanel();
+
+    expect(screen.getByText('https://bridge.simplefin.org/••••••')).toBeInTheDocument();
+  });
+
+  it('requires confirmation before disconnecting', async () => {
+    const { host, onDisconnected } = renderPanel();
+    host.secrets.set(AUTH_SECRET_KEY, 'secret');
+
+    await userEvent.click(screen.getByRole('button', { name: /disconnect/i }));
+
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(host.secrets.get(AUTH_SECRET_KEY)).toBe('secret');
+  });
+
+  it('clears the stored credential and config, then notifies the parent on confirm', async () => {
+    const { host, onDisconnected } = renderPanel();
+    host.secrets.set(AUTH_SECRET_KEY, 'secret');
+    host.storage.set('simplefin.config', JSON.stringify({ baseUrl: BASE_URL, mappings: [] }));
+
+    await userEvent.click(screen.getByRole('button', { name: /disconnect/i }));
+    await userEvent.click(await screen.findByRole('button', { name: /yes, disconnect/i }));
+
+    expect(host.secrets.get(AUTH_SECRET_KEY)).toBeUndefined();
+    expect(JSON.parse(host.storage.get('simplefin.config') as string)).toEqual({
+      baseUrl: null,
+      mappings: [],
+      lookbackDays: DEFAULT_LOOKBACK_DAYS,
+    });
+    expect(onDisconnected).toHaveBeenCalled();
+  });
+
+  it('surfaces a disconnect failure instead of silently notifying the parent', async () => {
+    const { host, onDisconnected } = renderPanel();
+    host.api.secrets.delete = vi.fn(async () => {
+      throw new Error('keyring unavailable');
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /disconnect/i }));
+    await userEvent.click(await screen.findByRole('button', { name: /yes, disconnect/i }));
+
+    expect(await screen.findByText(/keyring unavailable/i)).toBeInTheDocument();
+    expect(onDisconnected).not.toHaveBeenCalled();
+  });
+
+  it('disables Save until the lookback window actually changes to a valid value', async () => {
+    renderPanel({ lookbackDays: 30 });
+    const input = screen.getByLabelText(/lookback window/i);
+    const save = screen.getByRole('button', { name: /^save$/i });
+
+    expect(save).toBeDisabled();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '0');
+    expect(save).toBeDisabled();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '60');
+    expect(save).toBeEnabled();
+  });
+
+  it('saves the parsed lookback window as a number', async () => {
+    const { onLookbackDaysChange } = renderPanel({ lookbackDays: 30 });
+    const input = screen.getByLabelText(/lookback window/i);
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '90');
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(onLookbackDaysChange).toHaveBeenCalledWith(90);
+  });
+});

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,0 +1,143 @@
+import type { HostAPI } from '@wealthfolio/addon-sdk';
+import {
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from '@wealthfolio/ui';
+import { useState } from 'react';
+import { AUTH_SECRET_KEY } from '../lib/simplefin/client';
+import { maskBaseUrl } from '../lib/simplefin/url';
+import { emptyConfig, writeConfig } from '../lib/storage/config';
+
+export interface SettingsPanelProps {
+  api: HostAPI;
+  baseUrl: string;
+  lookbackDays: number;
+  onLookbackDaysChange: (days: number) => void;
+  onDisconnected: () => void;
+}
+
+function isValidLookback(value: string): boolean {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 1;
+}
+
+export function SettingsPanel({
+  api,
+  baseUrl,
+  lookbackDays,
+  onLookbackDaysChange,
+  onDisconnected,
+}: SettingsPanelProps) {
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lookbackDraft, setLookbackDraft] = useState(String(lookbackDays));
+
+  async function handleDisconnect() {
+    setError(null);
+    setDisconnecting(true);
+    try {
+      await api.secrets.delete(AUTH_SECRET_KEY);
+      await writeConfig(api, emptyConfig());
+      onDisconnected();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setDisconnecting(false);
+    }
+  }
+
+  function handleSaveLookback() {
+    onLookbackDaysChange(Number(lookbackDraft));
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <Alert variant="destructive" role="alert">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+      <Card>
+        <CardHeader>
+          <CardTitle>Connection</CardTitle>
+          <CardDescription>Manage the SimpleFIN Bridge connection for this addon.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>SimpleFIN Bridge URL</Label>
+            <p className="text-muted-foreground text-sm">{maskBaseUrl(baseUrl)}</p>
+          </div>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive" disabled={disconnecting}>
+                {disconnecting ? 'Disconnecting…' : 'Disconnect'}
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Disconnect SimpleFIN Bridge?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This clears the stored SimpleFIN credentials and all account mappings.
+                  You&apos;ll need to reconnect with a new setup token to sync again.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={handleDisconnect}>Yes, disconnect</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Sync</CardTitle>
+          <CardDescription>
+            Every sync reaches back at least this many days, so a newly mapped account gets its
+            history even if your other accounts are already caught up.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="lookback-days">Lookback window (days)</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="lookback-days"
+                type="number"
+                min={1}
+                step={1}
+                className="w-24"
+                value={lookbackDraft}
+                onChange={(e) => setLookbackDraft(e.target.value)}
+              />
+              <Button
+                onClick={handleSaveLookback}
+                disabled={
+                  !isValidLookback(lookbackDraft) || Number(lookbackDraft) === lookbackDays
+                }
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/SetupCard.tsx
+++ b/src/components/SetupCard.tsx
@@ -15,7 +15,7 @@ import { useState } from 'react';
 import { AUTH_SECRET_KEY } from '../lib/simplefin/client';
 import { claimSetupToken } from '../lib/simplefin/claim';
 import { splitAccessUrl } from '../lib/simplefin/url';
-import { writeConfig } from '../lib/storage/config';
+import { DEFAULT_LOOKBACK_DAYS, writeConfig } from '../lib/storage/config';
 
 export interface SetupCardProps {
   api: HostAPI;
@@ -34,7 +34,7 @@ export function SetupCard({ api, onConnected }: SetupCardProps) {
       const accessUrl = await claimSetupToken(api.network, token);
       const { baseUrl, basicAuthSecret } = splitAccessUrl(accessUrl);
       await api.secrets.set(AUTH_SECRET_KEY, basicAuthSecret);
-      await writeConfig(api, { baseUrl, mappings: [] });
+      await writeConfig(api, { baseUrl, mappings: [], lookbackDays: DEFAULT_LOOKBACK_DAYS });
       onConnected();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));

--- a/src/components/SyncSummary.tsx
+++ b/src/components/SyncSummary.tsx
@@ -1,5 +1,6 @@
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@wealthfolio/ui';
+import { cn, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@wealthfolio/ui';
 import type { AccountRunResult, SyncRun } from '../lib/storage/history';
+import { compactCellClassName, compactHeadClassName } from './tableStyle';
 
 export interface SyncSummaryProps {
   run: SyncRun;
@@ -21,27 +22,37 @@ export function SyncSummary({ run }: SyncSummaryProps) {
     <Table aria-label="Sync results">
       <TableHeader>
         <TableRow>
-          <TableHead>Account</TableHead>
-          <TableHead>Imported</TableHead>
-          <TableHead>Skipped</TableHead>
-          <TableHead>Duplicates</TableHead>
-          <TableHead>Total</TableHead>
-          <TableHead>Balance</TableHead>
+          <TableHead className={compactHeadClassName}>Account</TableHead>
+          <TableHead className={cn(compactHeadClassName, 'text-right')}>Imported</TableHead>
+          <TableHead className={cn(compactHeadClassName, 'text-right')}>Skipped</TableHead>
+          <TableHead className={cn(compactHeadClassName, 'text-right')}>Duplicates</TableHead>
+          <TableHead className={cn(compactHeadClassName, 'text-right')}>Total</TableHead>
+          <TableHead className={compactHeadClassName}>Balance</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {run.accounts.map((result) => (
           <TableRow key={result.sfAccountId}>
-            <TableCell>{result.sfAccountName}</TableCell>
+            <TableCell className={compactCellClassName}>{result.sfAccountName}</TableCell>
             {result.error ? (
-              <TableCell colSpan={5}>Failed: {result.error}</TableCell>
+              <TableCell className={compactCellClassName} colSpan={5}>
+                Failed: {result.error}
+              </TableCell>
             ) : (
               <>
-                <TableCell>{cell(result.imported)}</TableCell>
-                <TableCell>{cell(result.skipped)}</TableCell>
-                <TableCell>{cell(result.duplicates)}</TableCell>
-                <TableCell>{cell(totalFor(result))}</TableCell>
-                <TableCell>
+                <TableCell className={cn(compactCellClassName, 'text-right tabular-nums')}>
+                  {cell(result.imported)}
+                </TableCell>
+                <TableCell className={cn(compactCellClassName, 'text-right tabular-nums')}>
+                  {cell(result.skipped)}
+                </TableCell>
+                <TableCell className={cn(compactCellClassName, 'text-right tabular-nums')}>
+                  {cell(result.duplicates)}
+                </TableCell>
+                <TableCell className={cn(compactCellClassName, 'text-right tabular-nums')}>
+                  {cell(totalFor(result))}
+                </TableCell>
+                <TableCell className={compactCellClassName}>
                   {result.balanceMismatch
                     ? `SimpleFIN ${result.balanceMismatch.simplefin} vs Wealthfolio ${result.balanceMismatch.wealthfolio}`
                     : '—'}

--- a/src/components/tableStyle.ts
+++ b/src/components/tableStyle.ts
@@ -1,0 +1,6 @@
+/**
+ * Overrides the UI kit's default Table cell padding (`h-12 px-4` / `p-4`),
+ * which reads as too spacious for these dense sync tables.
+ */
+export const compactHeadClassName = 'h-8 px-3 py-1.5';
+export const compactCellClassName = 'px-3 py-1.5';

--- a/src/lib/simplefin/url.test.ts
+++ b/src/lib/simplefin/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { bridgeDashboardUrl, splitAccessUrl } from './url';
+import { bridgeDashboardUrl, maskBaseUrl, splitAccessUrl } from './url';
 
 describe('splitAccessUrl', () => {
   it('separates credentials from the base URL', () => {
@@ -39,6 +39,14 @@ describe('bridgeDashboardUrl', () => {
   it('reduces to scheme and host', () => {
     expect(bridgeDashboardUrl('https://bridge.simplefin.org/simplefin')).toBe(
       'https://bridge.simplefin.org',
+    );
+  });
+});
+
+describe('maskBaseUrl', () => {
+  it('keeps the origin but hides the path', () => {
+    expect(maskBaseUrl('https://bridge.simplefin.org/simplefin')).toBe(
+      'https://bridge.simplefin.org/••••••',
     );
   });
 });

--- a/src/lib/simplefin/url.ts
+++ b/src/lib/simplefin/url.ts
@@ -43,3 +43,12 @@ export function bridgeDashboardUrl(baseUrl: string): string {
   const url = new URL(baseUrl);
   return `${url.protocol}//${url.host}`;
 }
+
+/**
+ * Shown in Settings instead of the full base URL — the path segment can still
+ * act as a semi-identifying token even though it carries no credentials.
+ */
+export function maskBaseUrl(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  return `${url.protocol}//${url.host}/••••••`;
+}

--- a/src/lib/storage/config.test.ts
+++ b/src/lib/storage/config.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { createMockHost } from '../../test/mockHost';
-import { readConfig, writeConfig } from './config';
+import { DEFAULT_LOOKBACK_DAYS, readConfig, writeConfig } from './config';
 
 describe('config', () => {
   it('returns an empty config when nothing is stored', async () => {
     const host = createMockHost();
-    expect(await readConfig(host.api)).toEqual({ baseUrl: null, mappings: [] });
+    expect(await readConfig(host.api)).toEqual({
+      baseUrl: null,
+      mappings: [],
+      lookbackDays: DEFAULT_LOOKBACK_DAYS,
+    });
   });
 
   it('round-trips a config', async () => {
@@ -21,9 +25,23 @@ describe('config', () => {
           orgName: 'Test Bank',
         },
       ],
+      lookbackDays: 60,
     };
     await writeConfig(host.api, config);
     expect(await readConfig(host.api)).toEqual(config);
+  });
+
+  it('defaults lookbackDays for a config written before the field existed', async () => {
+    const host = createMockHost();
+    await host.api.storage.set(
+      'simplefin.config',
+      JSON.stringify({ baseUrl: 'https://bridge.simplefin.org/simplefin', mappings: [] }),
+    );
+    expect(await readConfig(host.api)).toEqual({
+      baseUrl: 'https://bridge.simplefin.org/simplefin',
+      mappings: [],
+      lookbackDays: DEFAULT_LOOKBACK_DAYS,
+    });
   });
 
   it('never stores credentials in the base URL', async () => {
@@ -31,6 +49,7 @@ describe('config', () => {
     await writeConfig(host.api, {
       baseUrl: 'https://bridge.simplefin.org/simplefin',
       mappings: [],
+      lookbackDays: DEFAULT_LOOKBACK_DAYS,
     });
     const stored = [...host.storage.values()].join('');
     expect(stored).not.toContain('@');
@@ -39,7 +58,11 @@ describe('config', () => {
   it('recovers from a corrupt config rather than throwing', async () => {
     const host = createMockHost();
     await host.api.storage.set('simplefin.config', '{not json');
-    expect(await readConfig(host.api)).toEqual({ baseUrl: null, mappings: [] });
+    expect(await readConfig(host.api)).toEqual({
+      baseUrl: null,
+      mappings: [],
+      lookbackDays: DEFAULT_LOOKBACK_DAYS,
+    });
     expect(host.api.logger.error).toHaveBeenCalled();
   });
 });

--- a/src/lib/storage/config.ts
+++ b/src/lib/storage/config.ts
@@ -17,12 +17,17 @@ export interface SyncConfig {
   /** Credential-free SimpleFIN base URL. Credentials live in `secrets`. */
   baseUrl: string | null;
   mappings: AccountMapping[];
+  /** Floor on how far back a sync ever asks the Bridge for, in days. */
+  lookbackDays: number;
 }
+
+/** One statement cycle — enough to seed a new account without an unbounded first pull. */
+export const DEFAULT_LOOKBACK_DAYS = 30;
 
 const CONFIG_KEY = storageKey('config');
 
 export function emptyConfig(): SyncConfig {
-  return { baseUrl: null, mappings: [] };
+  return { baseUrl: null, mappings: [], lookbackDays: DEFAULT_LOOKBACK_DAYS };
 }
 
 export async function readConfig(api: HostAPI): Promise<SyncConfig> {
@@ -30,7 +35,10 @@ export async function readConfig(api: HostAPI): Promise<SyncConfig> {
   if (!raw) return emptyConfig();
 
   try {
-    return JSON.parse(raw) as SyncConfig;
+    const parsed = JSON.parse(raw) as Partial<SyncConfig>;
+    // `lookbackDays` was added after configs already existed in the wild;
+    // default it for anything written by an older version of the addon.
+    return { ...emptyConfig(), ...parsed };
   } catch (error) {
     // Returning empty sends the user back to setup, which is recoverable;
     // throwing here would leave the addon permanently unopenable.

--- a/src/lib/sync/activities.test.ts
+++ b/src/lib/sync/activities.test.ts
@@ -54,6 +54,14 @@ describe('toActivityImport', () => {
     const activity = toActivityImport(txn() as never, mapping, 'USD');
     expect(activity.date).toBe('2025-08-06');
   });
+
+  it('sets symbol to an empty string, since the host rejects the whole batch if it is absent', () => {
+    // Regression test: the host's import endpoint deserializes `symbol` as a
+    // required field even though the addon-sdk types call it optional —
+    // omitting it causes checkImport to fail instantly for every row.
+    const activity = toActivityImport(txn() as never, mapping, 'USD');
+    expect(activity.symbol).toBe('');
+  });
 });
 
 describe('syncCashAccount', () => {
@@ -193,5 +201,38 @@ describe('syncCashAccount', () => {
     await expect(
       syncCashAccount(host.api, mapping, account([txn()]) as never, before),
     ).rejects.toThrow(/host exploded/);
+  });
+
+  it('logs the rejected payload when checkImport itself throws, so the failing row is visible', async () => {
+    const host = createMockHost();
+    host.api.activities.checkImport = vi.fn(async () => {
+      throw new Error('Unprocessable Entity');
+    });
+
+    await expect(
+      syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark()),
+    ).rejects.toThrow(/Unprocessable Entity/);
+
+    expect(host.api.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(mapping.sfAccountName),
+    );
+    expect(host.api.logger.error).toHaveBeenCalledWith(expect.stringContaining('"symbol":""'));
+  });
+
+  it('logs the rejected payload when the host import throws, so the failing row is visible', async () => {
+    const host = createMockHost();
+    host.api.activities.checkImport = vi.fn(async (a) => a);
+    host.api.activities.import = vi.fn(async () => {
+      throw new Error('Unprocessable Entity');
+    });
+
+    await expect(
+      syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark()),
+    ).rejects.toThrow(/Unprocessable Entity/);
+
+    expect(host.api.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(mapping.sfAccountName),
+    );
+    expect(host.api.logger.error).toHaveBeenCalledWith(expect.stringContaining('"amount":"42.10"'));
   });
 });

--- a/src/lib/sync/activities.ts
+++ b/src/lib/sync/activities.ts
@@ -27,6 +27,11 @@ export function toActivityImport(
     date: isoDate(txn.posted),
     amount: magnitude,
     currency,
+    // Cash activities have no ticker. The addon-sdk types this as optional,
+    // but the host's import endpoint deserializes it as a required field and
+    // rejects the whole batch with an instant 422 if it's absent — confirmed
+    // against a live host (SDK 3.6.2 vs host 3.6.3 version skew).
+    symbol: '',
     comment: txn.payee || txn.description,
     isValid: true,
     isDraft: false,
@@ -54,7 +59,19 @@ export async function syncCashAccount(
   }
 
   const rows = candidates.map((t) => toActivityImport(t, mapping, sfAccount.currency));
-  const checked = await api.activities.checkImport(rows);
+  let checked;
+  try {
+    checked = await api.activities.checkImport(rows);
+  } catch (error) {
+    // A rejection here means the host rejected the request itself (e.g. a
+    // required field the addon-sdk types don't yet reflect) rather than
+    // flagging individual rows — log the payload so the mismatch is visible.
+    api.logger.error(
+      `[simplefin] activities.checkImport rejected ${rows.length} row(s) for ` +
+        `${mapping.sfAccountName}: ${JSON.stringify(rows)}`,
+    );
+    throw error;
+  }
 
   // checkImport annotates each row. Host-detected duplicates are a secondary
   // guard behind our own watermark; we never force-import over them.
@@ -93,7 +110,20 @@ export async function syncCashAccount(
     return { result: { imported: 0, skipped, duplicates }, watermark: advanced };
   }
 
-  const outcome = await api.activities.import(importable);
+  let outcome;
+  try {
+    outcome = await api.activities.import(importable);
+  } catch (error) {
+    // `checkImport` marked these rows valid, so a rejection here means the
+    // host's import-time validation caught something checkImport didn't —
+    // log the exact payload so the failing field is visible next run instead
+    // of just the bare HTTP status text.
+    api.logger.error(
+      `[simplefin] activities.import rejected ${importable.length} row(s) for ` +
+        `${mapping.sfAccountName}: ${JSON.stringify(importable)}`,
+    );
+    throw error;
+  }
 
   return {
     result: { imported: outcome.summary.imported, skipped, duplicates },

--- a/src/lib/sync/openingBalance.test.ts
+++ b/src/lib/sync/openingBalance.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { AccountMapping } from '../storage/config';
+import { buildOpeningBalanceActivity, subtractDecimal } from './openingBalance';
+
+describe('subtractDecimal', () => {
+  it('subtracts two decimal strings without float rounding', () => {
+    expect(subtractDecimal('100.00', '80.00')).toBe('20.00');
+  });
+
+  it('produces a negative result when b exceeds a', () => {
+    expect(subtractDecimal('50.00', '80.00')).toBe('-30.00');
+  });
+
+  it('produces a bare zero, never "-0", when the operands are equal', () => {
+    expect(subtractDecimal('50.00', '50.00')).toBe('0.00');
+  });
+
+  it('scales operands with differing decimal precision to the wider one', () => {
+    expect(subtractDecimal('100', '99.999')).toBe('0.001');
+  });
+
+  it('returns an integer string when neither operand has a fraction', () => {
+    expect(subtractDecimal('100', '80')).toBe('20');
+  });
+});
+
+describe('buildOpeningBalanceActivity', () => {
+  const mapping: AccountMapping = {
+    sfAccountId: 'ACT-1',
+    wfAccountId: 'WF-1',
+    mode: 'CASH',
+    sfAccountName: 'Checking',
+    orgName: 'Test Bank',
+  };
+
+  it('returns null when the SimpleFIN and Wealthfolio balances already agree', () => {
+    const activity = buildOpeningBalanceActivity(
+      { sfBalance: '100.00', wfBalance: '100.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
+      mapping,
+      'USD',
+    );
+    expect(activity).toBeNull();
+  });
+
+  it('builds a TRANSFER_IN when Wealthfolio is short of the SimpleFIN balance', () => {
+    const activity = buildOpeningBalanceActivity(
+      { sfBalance: '100.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
+      mapping,
+      'USD',
+    );
+    expect(activity?.activityType).toBe('TRANSFER_IN');
+    expect(activity?.amount).toBe('20.00');
+    expect(activity?.accountId).toBe('WF-1');
+    expect(activity?.currency).toBe('USD');
+  });
+
+  it('builds a TRANSFER_OUT when Wealthfolio holds more than the SimpleFIN balance', () => {
+    const activity = buildOpeningBalanceActivity(
+      { sfBalance: '50.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
+      mapping,
+      'USD',
+    );
+    expect(activity?.activityType).toBe('TRANSFER_OUT');
+    expect(activity?.amount).toBe('30.00');
+  });
+
+  it('dates the entry one day before the earliest posted transaction', () => {
+    const activity = buildOpeningBalanceActivity(
+      { sfBalance: '100.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
+      mapping,
+      'USD',
+    );
+    // earliestPosted 1754438400 -> 2025-08-06; one day before -> 2025-08-05
+    expect(activity?.date).toBe('2025-08-05');
+  });
+
+  it('falls back to the balance date when there is no transaction to anchor to', () => {
+    const activity = buildOpeningBalanceActivity(
+      { sfBalance: '100.00', wfBalance: '0', earliestPosted: null, balanceDate: 1754524800 },
+      mapping,
+      'USD',
+    );
+    expect(activity?.date).toBe('2025-08-07');
+  });
+
+  it('sets symbol to an empty string, matching the host requirement for cash activities', () => {
+    const activity = buildOpeningBalanceActivity(
+      { sfBalance: '100.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
+      mapping,
+      'USD',
+    );
+    expect(activity?.symbol).toBe('');
+  });
+});

--- a/src/lib/sync/openingBalance.ts
+++ b/src/lib/sync/openingBalance.ts
@@ -1,0 +1,83 @@
+import type { ActivityImport } from '@wealthfolio/addon-sdk';
+import type { AccountMapping } from '../storage/config';
+
+const SECONDS_PER_DAY = 86_400;
+
+function parseParts(value: string): { negative: boolean; whole: string; frac: string } {
+  const trimmed = value.trim();
+  const negative = trimmed.startsWith('-');
+  const unsigned = trimmed.replace(/^[-+]/, '');
+  const [whole, frac = ''] = unsigned.split('.');
+  return { negative, whole: whole || '0', frac };
+}
+
+/**
+ * Subtracts two signed decimal strings via scaled BigInt arithmetic, never
+ * going through float — money must not accumulate rounding error. Output is
+ * padded to the wider of the two operands' decimal precision.
+ */
+export function subtractDecimal(a: string, b: string): string {
+  const pa = parseParts(a);
+  const pb = parseParts(b);
+  const decimalPlaces = Math.max(pa.frac.length, pb.frac.length);
+
+  const toScaledBigInt = (p: ReturnType<typeof parseParts>): bigint => {
+    const paddedFrac = p.frac.padEnd(decimalPlaces, '0');
+    const magnitude = BigInt(`${p.whole}${paddedFrac}` || '0');
+    return p.negative ? -magnitude : magnitude;
+  };
+
+  const diff = toScaledBigInt(pa) - toScaledBigInt(pb);
+  const sign = diff < 0n ? '-' : '';
+  const absDigits = (diff < 0n ? -diff : diff).toString().padStart(decimalPlaces + 1, '0');
+
+  if (decimalPlaces === 0) return `${sign}${absDigits}`;
+
+  const whole = absDigits.slice(0, -decimalPlaces);
+  const frac = absDigits.slice(-decimalPlaces);
+  return `${sign}${whole}.${frac}`;
+}
+
+export interface OpeningBalanceInput {
+  sfBalance: string;
+  wfBalance: string;
+  /** Epoch seconds of the earliest posted transaction pulled this run, or null if there were none. */
+  earliestPosted: number | null;
+  /** Epoch seconds; used as the entry date when there is no transaction to anchor to. */
+  balanceDate: number;
+}
+
+function isoDate(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toISOString().slice(0, 10);
+}
+
+/**
+ * One-time synthetic activity that plugs the gap between SimpleFIN's current
+ * balance and whatever landed in Wealthfolio from the full-history backfill —
+ * returns null when there is no gap.
+ */
+export function buildOpeningBalanceActivity(
+  input: OpeningBalanceInput,
+  mapping: AccountMapping,
+  currency: string,
+): ActivityImport | null {
+  const remainder = subtractDecimal(input.sfBalance, input.wfBalance);
+  if (/^0(\.0*)?$/.test(remainder)) return null;
+
+  const isOutflow = remainder.startsWith('-');
+  const magnitude = remainder.replace(/^-/, '');
+  const dateEpoch =
+    input.earliestPosted !== null ? input.earliestPosted - SECONDS_PER_DAY : input.balanceDate;
+
+  return {
+    accountId: mapping.wfAccountId,
+    activityType: isOutflow ? 'TRANSFER_OUT' : 'TRANSFER_IN',
+    date: isoDate(dateEpoch),
+    amount: magnitude,
+    currency,
+    symbol: '',
+    comment: 'Opening balance (SimpleFIN migration)',
+    isValid: true,
+    isDraft: false,
+  };
+}

--- a/src/lib/sync/run.test.ts
+++ b/src/lib/sync/run.test.ts
@@ -189,3 +189,118 @@ describe('runSync', () => {
     expect(startDate).toBeLessThan(lookbackFloor);
   });
 });
+
+describe('runSync opening-balance backfill', () => {
+  const backfillConfig: SyncConfig = {
+    baseUrl: 'https://bridge.simplefin.org/simplefin',
+    mappings: [
+      {
+        sfAccountId: 'ACT-1',
+        wfAccountId: 'WF-1',
+        mode: 'CASH',
+        sfAccountName: 'Checking',
+        orgName: 'Bank A',
+      },
+    ],
+    lookbackDays: 30,
+  };
+
+  /** A Wealthfolio account whose balance actually moves as activities are pushed. */
+  function backfillHost(sfBalance: string, transactions: unknown[]) {
+    const host = createMockHost();
+    host.respond(/\/accounts/, {
+      body: JSON.stringify({
+        errors: [],
+        accounts: [
+          {
+            org: { name: 'Bank A' },
+            id: 'ACT-1',
+            name: 'Checking',
+            currency: 'USD',
+            balance: sfBalance,
+            'balance-date': 1754524800,
+            transactions,
+            holdings: [],
+          },
+        ],
+      }),
+    });
+
+    let wfBalance = 0;
+    const pushed: ActivityImport[] = [];
+
+    host.api.activities.checkImport = vi.fn(async (a: ActivityImport[]) =>
+      a.map((row) => ({ ...row, isValid: true })),
+    );
+    host.api.activities.import = vi.fn(async (rows: ActivityImport[]) => {
+      for (const row of rows) {
+        pushed.push(row);
+        const amount = Number(row.amount);
+        wfBalance += row.activityType === 'WITHDRAWAL' || row.activityType === 'TRANSFER_OUT' ? -amount : amount;
+      }
+      return {
+        activities: [],
+        importRunId: 'R',
+        summary: { total: rows.length, imported: rows.length, skipped: 0, duplicates: 0, assetsCreated: 0, success: true },
+      };
+    });
+    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', balance: wfBalance } as never]);
+
+    return { host, pushed };
+  }
+
+  it('pushes a TRANSFER_IN opening-balance entry that closes the gap on first sync', async () => {
+    const { host, pushed } = backfillHost('100.00', [
+      { id: 'T1', posted: 1754438400, amount: '-10.00', description: 'X' },
+    ]);
+
+    const run = await runSync(host.api, backfillConfig);
+
+    expect(pushed).toHaveLength(2);
+    expect(pushed[0].activityType).toBe('WITHDRAWAL');
+    expect(pushed[1].activityType).toBe('TRANSFER_IN');
+    expect(pushed[1].amount).toBe('110.00');
+    expect(run.accounts[0].imported).toBe(2);
+  });
+
+  it('fetches full unbounded history scoped to the account on first sync', async () => {
+    const { host } = backfillHost('100.00', []);
+
+    await runSync(host.api, backfillConfig);
+
+    const backfillRequest = host.requests.find((r) => new URL(r.url).searchParams.get('start-date') === '0');
+    expect(backfillRequest).toBeDefined();
+    expect(new URL(backfillRequest!.url).searchParams.getAll('account')).toEqual(['ACT-1']);
+  });
+
+  it('skips the opening-balance entry when nothing needs to be plugged', async () => {
+    const { host, pushed } = backfillHost('10.00', [
+      { id: 'T1', posted: 1754438400, amount: '10.00', description: 'X' },
+    ]);
+
+    await runSync(host.api, backfillConfig);
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0].activityType).toBe('DEPOSIT');
+  });
+
+  it('does not run the backfill fetch for a mapping that has already synced', async () => {
+    const { host } = backfillHost('100.00', []);
+    await writeWatermark(host.api, 'ACT-1', { lastPosted: 1754438400, recentIds: [] });
+
+    await runSync(host.api, backfillConfig);
+
+    expect(host.requests).toHaveLength(1);
+  });
+
+  it('does not run the backfill path for a HOLDINGS mapping', async () => {
+    const { host } = backfillHost('100.00', []);
+
+    await runSync(host.api, {
+      ...backfillConfig,
+      mappings: [{ ...backfillConfig.mappings[0], mode: 'HOLDINGS' }],
+    });
+
+    expect(host.requests).toHaveLength(1);
+  });
+});

--- a/src/lib/sync/run.test.ts
+++ b/src/lib/sync/run.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ActivityImport } from '@wealthfolio/addon-sdk';
 import { createMockHost } from '../../test/mockHost';
 import type { SyncConfig } from '../storage/config';
+import { writeWatermark } from '../storage/watermark';
 import { runSync } from './run';
 
 const config: SyncConfig = {
@@ -22,6 +23,7 @@ const config: SyncConfig = {
       orgName: 'Bank B',
     },
   ],
+  lookbackDays: 30,
 };
 
 const bridgePayload = {
@@ -146,5 +148,44 @@ describe('runSync', () => {
   it('throws when there is no configured base URL', async () => {
     const host = okHost();
     await expect(runSync(host.api, { ...config, baseUrl: null })).rejects.toThrow(/not connected/i);
+  });
+
+  it('reaches back at least lookbackDays even when a sibling account already has a recent watermark', async () => {
+    const host = okHost();
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const SECONDS_PER_DAY = 86_400;
+    // ACT-1 already synced yesterday; ACT-2 was just mapped and has never synced.
+    // Without a lookback floor, the shared fetch window would be dominated by
+    // ACT-1's recent watermark and ACT-2 would never get its own history.
+    await writeWatermark(host.api, 'ACT-1', {
+      lastPosted: nowSeconds - SECONDS_PER_DAY,
+      recentIds: [],
+    });
+
+    await runSync(host.api, { ...config, lookbackDays: 5 });
+
+    const requestUrl = new URL(host.requests[0].url);
+    const startDate = Number(requestUrl.searchParams.get('start-date'));
+    const expectedFloor = nowSeconds - 5 * SECONDS_PER_DAY;
+    expect(startDate).toBeLessThanOrEqual(expectedFloor);
+  });
+
+  it('reaches back further than lookbackDays when a watermark is older still', async () => {
+    const host = okHost();
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const SECONDS_PER_DAY = 86_400;
+    // An account stuck for 60 days should still get its overlap re-fetch even
+    // though that's further back than the 5-day lookback floor.
+    await writeWatermark(host.api, 'ACT-1', {
+      lastPosted: nowSeconds - 60 * SECONDS_PER_DAY,
+      recentIds: [],
+    });
+
+    await runSync(host.api, { ...config, lookbackDays: 5 });
+
+    const requestUrl = new URL(host.requests[0].url);
+    const startDate = Number(requestUrl.searchParams.get('start-date'));
+    const lookbackFloor = nowSeconds - 5 * SECONDS_PER_DAY;
+    expect(startDate).toBeLessThan(lookbackFloor);
   });
 });

--- a/src/lib/sync/run.ts
+++ b/src/lib/sync/run.ts
@@ -94,13 +94,20 @@ export async function runSync(api: HostAPI, config: SyncConfig): Promise<SyncRun
   const watermarks = await Promise.all(
     config.mappings.map((m) => readWatermark(api, m.sfAccountId)),
   );
-  const oldest = watermarks.reduce(
+  const oldestWatermark = watermarks.reduce(
     (min, wm) => (wm.lastPosted > 0 && wm.lastPosted < min ? wm.lastPosted : min),
     Number.POSITIVE_INFINITY,
   );
-  const startDate = Number.isFinite(oldest)
-    ? Math.max(0, oldest - OVERLAP_DAYS * SECONDS_PER_DAY)
-    : undefined;
+  const watermarkFloor = oldestWatermark - OVERLAP_DAYS * SECONDS_PER_DAY;
+
+  // A mapping added after its sibling accounts already have recent watermarks
+  // would otherwise inherit their (much later) shared start date and never
+  // get its own history. `lookbackDays` guarantees every sync reaches back at
+  // least that far, regardless of what the other accounts' watermarks say.
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const lookbackFloor = nowSeconds - config.lookbackDays * SECONDS_PER_DAY;
+
+  const startDate = Math.max(0, Math.min(watermarkFloor, lookbackFloor));
 
   const { accounts, errors } = await fetchAccounts(api.network, config.baseUrl, {
     startDate,

--- a/src/lib/sync/run.ts
+++ b/src/lib/sync/run.ts
@@ -6,6 +6,7 @@ import { appendRun, type AccountRunResult, type SyncRun } from '../storage/histo
 import { readWatermark, writeWatermark } from '../storage/watermark';
 import { syncCashAccount } from './activities';
 import { compareBalances } from './balance';
+import { buildOpeningBalanceActivity } from './openingBalance';
 import { syncHoldingsAccount } from './snapshots';
 
 /**
@@ -16,8 +17,73 @@ import { syncHoldingsAccount } from './snapshots';
 const OVERLAP_DAYS = 7;
 const SECONDS_PER_DAY = 86_400;
 
+/**
+ * Full-history pull for a CASH mapping's first-ever sync. The shared batch
+ * fetch in runSync is deliberately windowed (lookbackDays), so a fresh
+ * mapping never gets more than one statement cycle from it — this is the
+ * separate, per-account counterpart that asks for everything the Bridge is
+ * willing to give, so the opening-balance plug below has as little gap as
+ * possible left to cover. An explicit epoch-0 startDate is used rather than
+ * omitting the param: the SimpleFIN spec treats an omitted start-date as
+ * bridge-implementation-defined, not a documented "give me everything".
+ */
+async function fetchFullHistory(
+  api: HostAPI,
+  baseUrl: string,
+  sfAccountId: string,
+): Promise<SfAccount | undefined> {
+  const { accounts } = await fetchAccounts(api.network, baseUrl, {
+    accountIds: [sfAccountId],
+    startDate: 0,
+  });
+  return accounts.find((a) => a.id === sfAccountId);
+}
+
+/**
+ * Plugs the gap between SimpleFIN's current balance and whatever the
+ * full-history pull actually landed in Wealthfolio, as one synthetic
+ * TRANSFER_IN/OUT activity. The gap is read from Wealthfolio's real balance
+ * after the push rather than tracked through the batch import's return value
+ * — `ImportActivitiesResult.summary` only carries counts, not which rows
+ * landed or their amounts, and diffing the account's actual balance sidesteps
+ * needing that: a retry after a partial failure just recomputes against
+ * whatever is really there, so a gap already closed comes out as zero and is
+ * skipped rather than double-plugged.
+ */
+async function pushOpeningBalance(
+  api: HostAPI,
+  mapping: AccountMapping,
+  sfAccount: SfAccount,
+): Promise<number> {
+  await api.portfolio.recalculate();
+  const wfAccount = (await api.accounts.getAll()).find((a) => a.id === mapping.wfAccountId);
+  if (!wfAccount) return 0;
+
+  const posted = sfAccount.transactions.filter((t) => !t.pending);
+  const earliestPosted = posted.length > 0 ? Math.min(...posted.map((t) => t.posted)) : null;
+
+  const plug = buildOpeningBalanceActivity(
+    {
+      sfBalance: sfAccount.balance,
+      wfBalance: String(wfAccount.balance),
+      earliestPosted,
+      balanceDate: sfAccount.balanceDate,
+    },
+    mapping,
+    sfAccount.currency,
+  );
+  if (!plug) return 0;
+
+  const [checked] = await api.activities.checkImport([plug]);
+  if (!checked.isValid || checked.duplicateOfId) return 0;
+
+  await api.activities.import([checked]);
+  return 1;
+}
+
 async function syncOne(
   api: HostAPI,
+  baseUrl: string,
   mapping: AccountMapping,
   sfAccount: SfAccount | undefined,
   wfBalances: Map<string, string>,
@@ -60,18 +126,31 @@ async function syncOne(
     }
 
     const watermark = await readWatermark(api, mapping.sfAccountId);
-    const { result, watermark: next } = await syncCashAccount(api, mapping, sfAccount, watermark);
+    const isFirstSync = watermark.lastPosted === 0;
+
+    // A fresh mapping never has enough in the shared, lookbackDays-windowed
+    // batch fetch to seed an accurate opening balance — pull this one
+    // account's full history separately before pushing anything.
+    const syncSfAccount = isFirstSync
+      ? ((await fetchFullHistory(api, baseUrl, mapping.sfAccountId)) ?? sfAccount)
+      : sfAccount;
+
+    const { result, watermark: next } = await syncCashAccount(api, mapping, syncSfAccount, watermark);
     await writeWatermark(api, mapping.sfAccountId, next);
+
+    const plugImported = isFirstSync ? await pushOpeningBalance(api, mapping, syncSfAccount) : 0;
 
     return {
       ...base,
-      imported: result.imported,
+      imported: result.imported + plugImported,
       skipped: result.skipped,
       duplicates: result.duplicates,
-      balanceMismatch: compareBalances(
-        sfAccount.balance,
-        wfBalances.get(mapping.wfAccountId) ?? null,
-      ),
+      // A first-sync account's balance was just brought into agreement by the
+      // plug above (or never disagreed); comparing against the pre-run
+      // snapshot in wfBalances would flag a stale, misleading mismatch.
+      balanceMismatch: isFirstSync
+        ? null
+        : compareBalances(sfAccount.balance, wfBalances.get(mapping.wfAccountId) ?? null),
     };
   } catch (error) {
     // Per-institution isolation is a hard invariant: record and continue.
@@ -133,7 +212,9 @@ export async function runSync(api: HostAPI, config: SyncConfig): Promise<SyncRun
   // run keeps one slow institution from being blamed for another's timeout.
   const results: AccountRunResult[] = [];
   for (const mapping of config.mappings) {
-    results.push(await syncOne(api, mapping, bySfId.get(mapping.sfAccountId), wfBalances));
+    results.push(
+      await syncOne(api, config.baseUrl, mapping, bySfId.get(mapping.sfAccountId), wfBalances),
+    );
   }
 
   const run: SyncRun = {

--- a/src/pages/SyncPage.sync.test.tsx
+++ b/src/pages/SyncPage.sync.test.tsx
@@ -53,6 +53,7 @@ describe('SyncPage sync trigger', () => {
     render(<SyncPage api={host.api} />);
     await screen.findByText('Checking');
     await userEvent.click(screen.getByRole('button', { name: /sync now/i }));
+    await userEvent.click(await screen.findByRole('tab', { name: /summary/i }));
 
     const resultsTable = await screen.findByRole('table', { name: /sync results/i });
     const row = within(resultsTable).getByText('Checking').closest('tr');
@@ -98,6 +99,7 @@ describe('SyncPage sync trigger', () => {
     render(<SyncPage api={host.api} />);
     await screen.findByText('Checking');
     await userEvent.click(screen.getByRole('button', { name: /sync now/i }));
+    await userEvent.click(await screen.findByRole('tab', { name: /summary/i }));
 
     const resultsTable = await screen.findByRole('table', { name: /sync results/i });
     expect(await within(resultsTable).findByText(/was not returned by the bridge/i)).toBeInTheDocument();
@@ -151,6 +153,7 @@ describe('SyncPage sync trigger', () => {
     render(<SyncPage api={host.api} />);
     await screen.findByText('Checking');
     await userEvent.click(screen.getByRole('button', { name: /sync now/i }));
+    await userEvent.click(await screen.findByRole('tab', { name: /summary/i }));
 
     const resultsTable = await screen.findByRole('table', { name: /sync results/i });
     expect(await within(resultsTable).findByText(/simplefin 150\.00 vs wealthfolio 100/i)).toBeInTheDocument();
@@ -236,6 +239,7 @@ describe('SyncPage sync trigger', () => {
     render(<SyncPage api={host.api} />);
     await screen.findByText('Checking');
     await userEvent.click(screen.getByRole('button', { name: /sync now/i }));
+    await userEvent.click(await screen.findByRole('tab', { name: /runs/i }));
 
     const historyTable = await screen.findByRole('table', { name: /sync history/i });
     const rows = within(historyTable).getAllByRole('row').slice(1); // drop header row

--- a/src/pages/SyncPage.sync.test.tsx
+++ b/src/pages/SyncPage.sync.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { createMockHost } from '../test/mockHost';
 import { appendRun } from '../lib/storage/history';
+import { writeWatermark } from '../lib/storage/watermark';
 import { SyncPage } from './SyncPage';
 
 function seedConfig(host: ReturnType<typeof createMockHost>, mappings: unknown[]) {
@@ -132,6 +133,10 @@ describe('SyncPage sync trigger', () => {
   it('renders both figures for an account with a balance mismatch', async () => {
     const host = createMockHost();
     seedConfig(host, [CHECKING_MAPPING]);
+    // Already synced: a first-sync mismatch is now auto-plugged rather than
+    // left as a standing mismatch, so this steady-state UI check needs an
+    // account past its first sync to exercise the mismatch path at all.
+    await writeWatermark(host.api, 'ACT-1', { lastPosted: 1700000000 - 86_400, recentIds: [] });
     host.respond(/\/accounts/, {
       body: JSON.stringify({
         accounts: [

--- a/src/pages/SyncPage.tsx
+++ b/src/pages/SyncPage.tsx
@@ -1,9 +1,10 @@
 import type { Account, HostAPI } from '@wealthfolio/addon-sdk';
-import { Alert, AlertDescription, Button } from '@wealthfolio/ui';
+import { Alert, AlertDescription, Button, Tabs, TabsContent, TabsList, TabsTrigger } from '@wealthfolio/ui';
 import { useEffect, useState } from 'react';
 import { AccountMapTable } from '../components/AccountMapTable';
 import { BridgeErrorBanner } from '../components/BridgeErrorBanner';
 import { HistoryList } from '../components/HistoryList';
+import { SettingsPanel } from '../components/SettingsPanel';
 import { SetupCard } from '../components/SetupCard';
 import { SyncSummary } from '../components/SyncSummary';
 import { fetchAccounts } from '../lib/simplefin/client';
@@ -85,6 +86,19 @@ export function SyncPage({ api }: SyncPageProps) {
     }
   }
 
+  async function persistLookbackDays(lookbackDays: number) {
+    if (!config) return;
+    const previous = config;
+    const next = { ...config, lookbackDays };
+    setConfig(next);
+    try {
+      await writeConfig(api, next);
+    } catch (err) {
+      setConfig(previous);
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
   if (!config) {
     return error ? (
       <Alert variant="destructive" role="alert">
@@ -104,31 +118,66 @@ export function SyncPage({ api }: SyncPageProps) {
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
-      <AccountMapTable
-        api={api}
-        sfAccounts={sfAccounts}
-        wfAccounts={wfAccounts}
-        mappings={config.mappings}
-        onChange={persistMappings}
-        onAccountCreated={(account) => setWfAccounts((prev) => [...prev, account])}
-      />
-      <div className="space-y-2">
-        <Button onClick={handleSync} disabled={syncing}>
-          {syncing ? 'Syncing…' : 'Sync now'}
-        </Button>
-        {syncError && (
-          <Alert variant="destructive" role="alert">
-            <AlertDescription>{syncError}</AlertDescription>
-          </Alert>
-        )}
-      </div>
       {lastRun && (
-        <>
-          <BridgeErrorBanner errors={lastRun.bridgeErrors} dashboardUrl={bridgeDashboardUrl(config.baseUrl)} />
-          <SyncSummary run={lastRun} />
-        </>
+        <BridgeErrorBanner errors={lastRun.bridgeErrors} dashboardUrl={bridgeDashboardUrl(config.baseUrl)} />
       )}
-      <HistoryList runs={history} />
+      <Tabs defaultValue="accounts" orientation="vertical" className="flex items-start gap-4">
+        <div className="flex w-40 shrink-0 flex-col gap-2">
+          <TabsList className="flex h-fit flex-col items-stretch gap-1">
+            <TabsTrigger value="accounts" className="justify-start">
+              Accounts
+            </TabsTrigger>
+            <TabsTrigger value="summary" className="justify-start">
+              Summary
+            </TabsTrigger>
+            <TabsTrigger value="runs" className="justify-start">
+              Runs
+            </TabsTrigger>
+            <TabsTrigger value="settings" className="justify-start">
+              Settings
+            </TabsTrigger>
+          </TabsList>
+          <Button onClick={handleSync} disabled={syncing}>
+            {syncing ? 'Syncing…' : 'Sync now'}
+          </Button>
+          {syncError && (
+            <Alert variant="destructive" role="alert">
+              <AlertDescription>{syncError}</AlertDescription>
+            </Alert>
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <TabsContent value="accounts" className="mt-0">
+            <AccountMapTable
+              api={api}
+              sfAccounts={sfAccounts}
+              wfAccounts={wfAccounts}
+              mappings={config.mappings}
+              onChange={persistMappings}
+              onAccountCreated={(account) => setWfAccounts((prev) => [...prev, account])}
+            />
+          </TabsContent>
+          <TabsContent value="summary" className="mt-0">
+            {lastRun ? (
+              <SyncSummary run={lastRun} />
+            ) : (
+              <p className="text-muted-foreground text-sm">Run a sync to see results.</p>
+            )}
+          </TabsContent>
+          <TabsContent value="runs" className="mt-0">
+            <HistoryList runs={history} />
+          </TabsContent>
+          <TabsContent value="settings" className="mt-0">
+            <SettingsPanel
+              api={api}
+              baseUrl={config.baseUrl}
+              lookbackDays={config.lookbackDays}
+              onLookbackDaysChange={persistLookbackDays}
+              onDisconnected={loadConfig}
+            />
+          </TabsContent>
+        </div>
+      </Tabs>
     </div>
   );
 }

--- a/src/test/mockHost.ts
+++ b/src/test/mockHost.ts
@@ -39,6 +39,7 @@ export function createMockHost(): MockHost {
     accounts: { getAll: vi.fn(async () => []), create: vi.fn() },
     activities: { checkImport: vi.fn(), import: vi.fn() },
     snapshots: { checkImport: vi.fn(), importSnapshots: vi.fn() },
+    portfolio: { recalculate: vi.fn(async () => {}) },
     logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn(), trace: vi.fn() },
   } as unknown as HostAPI;
 


### PR DESCRIPTION
## Summary
- Redesign the sync UI with tabs and a Settings panel (`99b2566`)
- Send the required `symbol` field on cash activity imports, fixing a host-side 422 (`71fde26`)
- Backfill an opening-balance `TRANSFER_IN`/`TRANSFER_OUT` activity on a CASH mapping's first sync, so a migrated account starts reconciled instead of silently short of its pre-window history (`7d2967c`, closes #48)

Closes #48

## Test plan
- [x] `pnpm test` — full suite green (123 tests)
- [x] `pnpm type-check` — clean
- [ ] Manual verification against a real self-hosted Wealthfolio via `pnpm dev:server`: map a fresh CASH account, run "Sync now", confirm the imported transactions plus one opening-balance entry bring the account's balance in line with SimpleFIN

🤖 Generated with [Claude Code](https://claude.com/claude-code)