### PR TITLE
fix: repair opening-balance backfill end-to-end

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -78,6 +78,14 @@
         { "name": "importSnapshots", "isDeclared": true, "isDetected": false }
       ],
       "purpose": "Import holdings snapshots for investment accounts."
+    },
+    {
+      "category": "portfolio",
+      "functions": [
+        { "name": "recalculate", "isDeclared": true, "isDetected": false },
+        { "name": "getLatestValuations", "isDeclared": true, "isDetected": false }
+      ],
+      "purpose": "Recalculate a CASH account's balance after backfilling its full history, so the opening-balance gap against SimpleFIN can be measured accurately."
     }
   ],
   "keywords": ["wealthfolio", "addon", "simplefin", "sync", "banking"],

--- a/src/lib/storage/watermark.ts
+++ b/src/lib/storage/watermark.ts
@@ -12,6 +12,12 @@ import { storageKey } from './keys';
  *    watermark but appearing in a later fetch) is recognised rather than
  *    re-sent.
  *
+ * Keyed by the Wealthfolio account id, not the SimpleFIN one: this is a record
+ * of what has landed in a given ledger, so remapping a SimpleFIN account to a
+ * fresh Wealthfolio account correctly looks like "never synced" for that
+ * destination, rather than inheriting progress that was made against a
+ * different one.
+ *
  * Bounded by construction: the host caps storage values at ~250 KB, which a
  * full ledger of every synced id would eventually exceed.
  */
@@ -62,8 +68,8 @@ export function advanceWatermark(wm: Watermark, pushed: WatermarkTxn[]): Waterma
   return { lastPosted: newest, recentIds: appended.slice(-RECENT_ID_WINDOW) };
 }
 
-export async function readWatermark(api: HostAPI, sfAccountId: string): Promise<Watermark> {
-  const raw = await api.storage.get(storageKey('wm', sfAccountId));
+export async function readWatermark(api: HostAPI, wfAccountId: string): Promise<Watermark> {
+  const raw = await api.storage.get(storageKey('wm', wfAccountId));
   if (!raw) return emptyWatermark();
   try {
     return JSON.parse(raw) as Watermark;
@@ -72,7 +78,7 @@ export async function readWatermark(api: HostAPI, sfAccountId: string): Promise<
     // and say so — a re-push is idempotent-ish via checkImport's duplicate
     // detection, whereas a hard failure would block the account forever.
     api.logger.error(
-      `[simplefin] corrupt watermark for ${sfAccountId}, resetting: ${String(error)}`,
+      `[simplefin] corrupt watermark for ${wfAccountId}, resetting: ${String(error)}`,
     );
     return emptyWatermark();
   }
@@ -80,12 +86,12 @@ export async function readWatermark(api: HostAPI, sfAccountId: string): Promise<
 
 export async function writeWatermark(
   api: HostAPI,
-  sfAccountId: string,
+  wfAccountId: string,
   wm: Watermark,
 ): Promise<void> {
-  await api.storage.set(storageKey('wm', sfAccountId), JSON.stringify(wm));
+  await api.storage.set(storageKey('wm', wfAccountId), JSON.stringify(wm));
 }
 
-export async function resetWatermark(api: HostAPI, sfAccountId: string): Promise<void> {
-  await api.storage.delete(storageKey('wm', sfAccountId));
+export async function resetWatermark(api: HostAPI, wfAccountId: string): Promise<void> {
+  await api.storage.delete(storageKey('wm', wfAccountId));
 }

--- a/src/lib/sync/activities.ts
+++ b/src/lib/sync/activities.ts
@@ -90,13 +90,23 @@ export async function syncCashAccount(
   watermark: Watermark,
   accountType: AccountType,
   paymentKeywords: string[],
-): Promise<{ result: CashSyncCounts; watermark: Watermark; candidates: StagedCandidate[] }> {
+): Promise<{
+  result: CashSyncCounts;
+  watermark: Watermark;
+  candidates: StagedCandidate[];
+  importedTxns: SfTransaction[];
+}> {
   // Pending transactions are excluded from v1: their id and amount can both
   // change once posted, which would push a row we could never reconcile.
   const candidates = sfAccount.transactions.filter((t) => !t.pending && shouldPush(watermark, t));
 
   if (candidates.length === 0) {
-    return { result: { imported: 0, skipped: 0, duplicates: 0 }, watermark, candidates: [] };
+    return {
+      result: { imported: 0, skipped: 0, duplicates: 0 },
+      watermark,
+      candidates: [],
+      importedTxns: [],
+    };
   }
 
   const rows = candidates.map((t) => toActivityImport(t, mapping, sfAccount.currency, accountType));
@@ -148,7 +158,12 @@ export async function syncCashAccount(
       watermark,
       candidates.filter((_, i) => checked[i].duplicateOfId),
     );
-    return { result: { imported: 0, skipped, duplicates }, watermark: advanced, candidates: [] };
+    return {
+      result: { imported: 0, skipped, duplicates },
+      watermark: advanced,
+      candidates: [],
+      importedTxns: [],
+    };
   }
 
   let outcome;
@@ -180,5 +195,6 @@ export async function syncCashAccount(
     // line is never reached and the watermark stays put, so the next run retries.
     watermark: advanceWatermark(watermark, importableTxns),
     candidates: stagedCandidates,
+    importedTxns: importableTxns,
   };
 }

--- a/src/lib/sync/openingBalance.ts
+++ b/src/lib/sync/openingBalance.ts
@@ -38,6 +38,16 @@ export function subtractDecimal(a: string, b: string): string {
   return `${sign}${whole}.${frac}`;
 }
 
+function negateDecimal(value: string): string {
+  if (/^0(\.0*)?$/.test(value.trim())) return value;
+  return value.trim().startsWith('-') ? value.trim().slice(1) : `-${value.trim()}`;
+}
+
+/** Sums signed decimal strings via `subtractDecimal`, so the same BigInt-safe arithmetic applies. */
+export function sumDecimal(values: string[]): string {
+  return values.reduce((acc, v) => subtractDecimal(acc, negateDecimal(v)), '0');
+}
+
 export interface OpeningBalanceInput {
   sfBalance: string;
   wfBalance: string;

--- a/src/lib/sync/run.test.ts
+++ b/src/lib/sync/run.test.ts
@@ -80,6 +80,10 @@ describe('runSync', () => {
 
   it('isolates a per-account failure so the others still sync', async () => {
     const host = okHost();
+    // Not testing first-sync backfill here — mark both accounts already
+    // synced so the opening-balance plug doesn't affect the imported counts.
+    await writeWatermark(host.api, 'WF-1', { lastPosted: 1754438400 - 86_400, recentIds: [] });
+    await writeWatermark(host.api, 'WF-2', { lastPosted: 1754438400 - 86_400, recentIds: [] });
     host.api.activities.import = vi.fn(async (rows: ActivityImport[]) => {
       if (rows[0].accountId === 'WF-1') throw new Error('WF-1 exploded');
       return {
@@ -160,10 +164,10 @@ describe('runSync', () => {
     const host = okHost();
     const nowSeconds = Math.floor(Date.now() / 1000);
     const SECONDS_PER_DAY = 86_400;
-    // ACT-1 already synced yesterday; ACT-2 was just mapped and has never synced.
+    // WF-1 already synced yesterday; WF-2 was just mapped and has never synced.
     // Without a lookback floor, the shared fetch window would be dominated by
-    // ACT-1's recent watermark and ACT-2 would never get its own history.
-    await writeWatermark(host.api, 'ACT-1', {
+    // WF-1's recent watermark and WF-2 would never get its own history.
+    await writeWatermark(host.api, 'WF-1', {
       lastPosted: nowSeconds - SECONDS_PER_DAY,
       recentIds: [],
     });
@@ -182,7 +186,7 @@ describe('runSync', () => {
     const SECONDS_PER_DAY = 86_400;
     // An account stuck for 60 days should still get its overlap re-fetch even
     // though that's further back than the 5-day lookback floor.
-    await writeWatermark(host.api, 'ACT-1', {
+    await writeWatermark(host.api, 'WF-1', {
       lastPosted: nowSeconds - 60 * SECONDS_PER_DAY,
       recentIds: [],
     });
@@ -468,7 +472,6 @@ describe('runSync opening-balance backfill', () => {
     paymentKeywords: ['PAYMENT', 'AUTOPAY', 'THANK YOU'],
   };
 
-  /** A Wealthfolio account whose balance actually moves as activities are pushed. */
   function backfillHost(sfBalance: string, transactions: unknown[]) {
     const host = createMockHost();
     host.respond(/\/accounts/, {
@@ -489,25 +492,19 @@ describe('runSync opening-balance backfill', () => {
       }),
     });
 
-    let wfBalance = 0;
     const pushed: ActivityImport[] = [];
 
     host.api.activities.checkImport = vi.fn(async (a: ActivityImport[]) =>
       a.map((row) => ({ ...row, isValid: true })),
     );
     host.api.activities.import = vi.fn(async (rows: ActivityImport[]) => {
-      for (const row of rows) {
-        pushed.push(row);
-        const amount = Number(row.amount);
-        wfBalance += row.activityType === 'WITHDRAWAL' || row.activityType === 'TRANSFER_OUT' ? -amount : amount;
-      }
+      pushed.push(...rows);
       return {
         activities: [],
         importRunId: 'R',
         summary: { total: rows.length, imported: rows.length, skipped: 0, duplicates: 0, assetsCreated: 0, success: true },
       };
     });
-    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', balance: wfBalance } as never]);
 
     return { host, pushed };
   }
@@ -526,13 +523,51 @@ describe('runSync opening-balance backfill', () => {
     expect(run.accounts[0].imported).toBe(2);
   });
 
-  it('fetches full unbounded history scoped to the account on first sync', async () => {
-    const { host } = backfillHost('100.00', []);
+  it('folds a pre-existing Wealthfolio balance into the plug instead of ignoring it', async () => {
+    // A Wealthfolio account can have unrelated activity before it's ever
+    // mapped to a SimpleFIN account — the plug must account for that
+    // pre-existing balance, not assume the account started at zero. This
+    // also guards against computing the plug from a live host read: a
+    // `portfolio.recalculate()` + `getLatestValuations()` call right after
+    // import is not guaranteed to reflect what was just pushed (confirmed
+    // against a live host), so the plug must be derived only from values
+    // already known to this run — the pre-sync snapshot and what it just
+    // imported — never re-queried afterwards.
+    const { host, pushed } = backfillHost('100.00', [
+      { id: 'T1', posted: 1754438400, amount: '-10.00', description: 'X' },
+    ]);
+    host.api.portfolio.getLatestValuations = vi.fn(async () => [
+      { accountId: 'WF-1', cashBalance: 500 } as never,
+    ]);
 
     await runSync(host.api, backfillConfig);
 
-    const backfillRequest = host.requests.find((r) => new URL(r.url).searchParams.get('start-date') === '0');
+    expect(pushed).toHaveLength(2);
+    expect(pushed[1].activityType).toBe('TRANSFER_OUT');
+    // sfBalance(100.00) - (preSync 500 + imported -10.00) = -390.00
+    expect(pushed[1].amount).toBe('390.00');
+  });
+
+  it('fetches history capped at the Bridge-safe window, scoped to the account, on first sync', async () => {
+    const { host } = backfillHost('100.00', []);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const SECONDS_PER_DAY = 86_400;
+
+    await runSync(host.api, backfillConfig);
+
+    // The shared batch fetch (fired first) also scopes to this one mapping's
+    // account, so take the *last* single-account request — the per-account
+    // full-history pull that fires afterwards in syncOne.
+    const singleAccountRequests = host.requests.filter(
+      (r) => new URL(r.url).searchParams.getAll('account').length === 1,
+    );
+    const backfillRequest = singleAccountRequests[singleAccountRequests.length - 1];
+    expect(singleAccountRequests.length).toBeGreaterThanOrEqual(2);
     expect(backfillRequest).toBeDefined();
+    const startDate = Number(new URL(backfillRequest!.url).searchParams.get('start-date'));
+    // 40 days back, give or take a second of test-run drift.
+    expect(startDate).toBeGreaterThan(nowSeconds - 41 * SECONDS_PER_DAY);
+    expect(startDate).toBeLessThanOrEqual(nowSeconds - 40 * SECONDS_PER_DAY);
     expect(new URL(backfillRequest!.url).searchParams.getAll('account')).toEqual(['ACT-1']);
   });
 
@@ -549,7 +584,7 @@ describe('runSync opening-balance backfill', () => {
 
   it('does not run the backfill fetch for a mapping that has already synced', async () => {
     const { host } = backfillHost('100.00', []);
-    await writeWatermark(host.api, 'ACT-1', { lastPosted: 1754438400, recentIds: [] });
+    await writeWatermark(host.api, 'WF-1', { lastPosted: 1754438400, recentIds: [] });
 
     await runSync(host.api, backfillConfig);
 

--- a/src/lib/sync/run.ts
+++ b/src/lib/sync/run.ts
@@ -1,13 +1,13 @@
 import type { AccountType, HostAPI } from '@wealthfolio/addon-sdk';
 import { fetchAccounts } from '../simplefin/client';
-import type { SfAccount } from '../simplefin/parse';
+import type { SfAccount, SfTransaction } from '../simplefin/parse';
 import { cashAccountIdsFrom, type AccountMapping, type SyncConfig } from '../storage/config';
 import { appendRun, type AccountRunResult, type SyncRun } from '../storage/history';
 import { readStaging, writeStaging, type StagedCandidate } from '../storage/staging';
 import { readWatermark, writeWatermark } from '../storage/watermark';
 import { syncCashAccount } from './activities';
 import { compareBalances } from './balance';
-import { buildOpeningBalanceActivity } from './openingBalance';
+import { buildOpeningBalanceActivity, sumDecimal } from './openingBalance';
 import { runReconciliation } from './reconciliation';
 import { syncHoldingsAccount } from './snapshots';
 
@@ -20,23 +20,30 @@ const OVERLAP_DAYS = 7;
 const SECONDS_PER_DAY = 86_400;
 
 /**
+ * The Bridge advises against requesting more than 45 days of history in one
+ * call (older requests come back with an advisory error). A first sync has
+ * no need to push right up against that limit anyway — the opening-balance
+ * plug below covers whatever real history this can't reach.
+ */
+const FULL_HISTORY_DAYS = 40;
+
+/**
  * Full-history pull for a CASH mapping's first-ever sync. The shared batch
  * fetch in runSync is deliberately windowed (lookbackDays), so a fresh
  * mapping never gets more than one statement cycle from it — this is the
- * separate, per-account counterpart that asks for everything the Bridge is
- * willing to give, so the opening-balance plug below has as little gap as
- * possible left to cover. An explicit epoch-0 startDate is used rather than
- * omitting the param: the SimpleFIN spec treats an omitted start-date as
- * bridge-implementation-defined, not a documented "give me everything".
+ * separate, per-account counterpart that asks for as much of that as the
+ * Bridge allows, so the opening-balance plug below has as little gap as
+ * possible left to cover.
  */
 async function fetchFullHistory(
   api: HostAPI,
   baseUrl: string,
   sfAccountId: string,
 ): Promise<SfAccount | undefined> {
+  const nowSeconds = Math.floor(Date.now() / 1000);
   const { accounts } = await fetchAccounts(api.network, baseUrl, {
     accountIds: [sfAccountId],
-    startDate: 0,
+    startDate: nowSeconds - FULL_HISTORY_DAYS * SECONDS_PER_DAY,
   });
   return accounts.find((a) => a.id === sfAccountId);
 }
@@ -44,22 +51,26 @@ async function fetchFullHistory(
 /**
  * Plugs the gap between SimpleFIN's current balance and whatever the
  * full-history pull actually landed in Wealthfolio, as one synthetic
- * TRANSFER_IN/OUT activity. The gap is read from Wealthfolio's real balance
- * after the push rather than tracked through the batch import's return value
- * — `ImportActivitiesResult.summary` only carries counts, not which rows
- * landed or their amounts, and diffing the account's actual balance sidesteps
- * needing that: a retry after a partial failure just recomputes against
- * whatever is really there, so a gap already closed comes out as zero and is
- * skipped rather than double-plugged.
+ * TRANSFER_IN/OUT activity.
+ *
+ * The post-import Wealthfolio balance is computed here, not read back from
+ * the host: `portfolio.recalculate()` resolving is not a reliable signal
+ * that `portfolio.getLatestValuations()` reflects the activities just
+ * imported — confirmed against a live host, where a `recalculate()` +
+ * `getLatestValuations()` read immediately after import came back against
+ * the pre-import (empty) balance, silently doubling the plug by the whole
+ * real-history total. `preSyncBalance` (read once, before this run touched
+ * anything) plus the signed sum of what actually got imported this run can't
+ * race with anything, since both are already-known values.
  */
 async function pushOpeningBalance(
   api: HostAPI,
   mapping: AccountMapping,
   sfAccount: SfAccount,
+  preSyncBalance: string | null,
+  importedTxns: SfTransaction[],
 ): Promise<number> {
-  await api.portfolio.recalculate();
-  const wfAccount = (await api.accounts.getAll()).find((a) => a.id === mapping.wfAccountId);
-  if (!wfAccount) return 0;
+  const wfBalance = sumDecimal([preSyncBalance ?? '0', ...importedTxns.map((t) => t.amount)]);
 
   const posted = sfAccount.transactions.filter((t) => !t.pending);
   const earliestPosted = posted.length > 0 ? Math.min(...posted.map((t) => t.posted)) : null;
@@ -67,7 +78,7 @@ async function pushOpeningBalance(
   const plug = buildOpeningBalanceActivity(
     {
       sfBalance: sfAccount.balance,
-      wfBalance: String(wfAccount.balance),
+      wfBalance,
       earliestPosted,
       balanceDate: sfAccount.balanceDate,
     },
@@ -135,7 +146,7 @@ async function syncOne(
       };
     }
 
-    const watermark = await readWatermark(api, mapping.sfAccountId);
+    const watermark = await readWatermark(api, mapping.wfAccountId);
     const isFirstSync = watermark.lastPosted === 0;
 
     // A fresh mapping never has enough in the shared, lookbackDays-windowed
@@ -145,7 +156,12 @@ async function syncOne(
       ? ((await fetchFullHistory(api, baseUrl, mapping.sfAccountId)) ?? sfAccount)
       : sfAccount;
 
-    const { result, watermark: next, candidates } = await syncCashAccount(
+    const {
+      result,
+      watermark: next,
+      candidates,
+      importedTxns,
+    } = await syncCashAccount(
       api,
       mapping,
       syncSfAccount,
@@ -153,9 +169,17 @@ async function syncOne(
       wfAccountTypes.get(mapping.wfAccountId) ?? 'CASH',
       paymentKeywords,
     );
-    await writeWatermark(api, mapping.sfAccountId, next);
+    await writeWatermark(api, mapping.wfAccountId, next);
 
-    const plugImported = isFirstSync ? await pushOpeningBalance(api, mapping, syncSfAccount) : 0;
+    const plugImported = isFirstSync
+      ? await pushOpeningBalance(
+          api,
+          mapping,
+          syncSfAccount,
+          wfBalances.get(mapping.wfAccountId) ?? null,
+          importedTxns,
+        )
+      : 0;
 
     return {
       accountResult: {
@@ -191,7 +215,7 @@ export async function runSync(api: HostAPI, config: SyncConfig): Promise<SyncRun
   // response also lets one institution's error surface alongside healthy data.
   // The window starts at the oldest watermark so no account is short-changed.
   const watermarks = await Promise.all(
-    config.mappings.map((m) => readWatermark(api, m.sfAccountId)),
+    config.mappings.map((m) => readWatermark(api, m.wfAccountId)),
   );
   const oldestWatermark = watermarks.reduce(
     (min, wm) => (wm.lastPosted > 0 && wm.lastPosted < min ? wm.lastPosted : min),
@@ -217,12 +241,22 @@ export async function runSync(api: HostAPI, config: SyncConfig): Promise<SyncRun
 
   // Wealthfolio balances for the post-sync mismatch check. A failure here must
   // not fail the run — the check is diagnostic, so it degrades to "unavailable".
+  // The balance comes from `portfolio.getLatestValuations` — confirmed against
+  // a live host that `accounts.getAll()` doesn't carry a `balance` field at all.
   const wfBalances = new Map<string, string>();
   const wfAccountTypes = new Map<string, AccountType>();
   try {
     for (const account of await api.accounts.getAll()) {
-      if (Number.isFinite(account.balance)) wfBalances.set(account.id, String(account.balance));
       wfAccountTypes.set(account.id, account.accountType);
+    }
+    await api.portfolio.recalculate();
+    const valuations = await api.portfolio.getLatestValuations(
+      config.mappings.map((m) => m.wfAccountId),
+    );
+    for (const valuation of valuations) {
+      if (Number.isFinite(valuation.cashBalance)) {
+        wfBalances.set(valuation.accountId, String(valuation.cashBalance));
+      }
     }
   } catch (error) {
     api.logger.error(
@@ -246,6 +280,15 @@ export async function runSync(api: HostAPI, config: SyncConfig): Promise<SyncRun
     );
     results.push(accountResult);
     detectedCandidates.push(...candidates);
+  }
+
+  // Best-effort: refresh the host's own cached valuations to reflect what
+  // this run just imported, for whatever reads them next. Nothing in this
+  // run's own results depends on it, so a failure here is not fatal.
+  try {
+    await api.portfolio.recalculate();
+  } catch (error) {
+    api.logger.error(`[simplefin] post-sync portfolio.recalculate failed: ${String(error)}`);
   }
 
   const cashAccountIds = cashAccountIdsFrom(config.mappings, (id) => wfAccountTypes.get(id));

--- a/src/pages/SyncPage.sync.test.tsx
+++ b/src/pages/SyncPage.sync.test.tsx
@@ -26,6 +26,9 @@ describe('SyncPage sync trigger', () => {
   it('calls runSync and renders per-account imported counts', async () => {
     const host = createMockHost();
     seedConfig(host, [CHECKING_MAPPING]);
+    // Not testing first-sync backfill here — mark it already synced so the
+    // opening-balance plug doesn't affect the imported count.
+    await writeWatermark(host.api, 'WF-1', { lastPosted: 1700000000 - 86_400, recentIds: [] });
     host.respond(/\/accounts/, {
       body: JSON.stringify({
         accounts: [
@@ -75,6 +78,9 @@ describe('SyncPage sync trigger', () => {
       orgName: 'Bank B',
     };
     seedConfig(host, [CHECKING_MAPPING, secondMapping]);
+    // Not testing first-sync backfill here — mark Checking already synced so
+    // the opening-balance plug doesn't affect its imported count.
+    await writeWatermark(host.api, 'WF-1', { lastPosted: 1700000000 - 86_400, recentIds: [] });
     host.respond(/\/accounts/, {
       // ACT-2 is absent from the Bridge response, so its sync fails automatically.
       body: JSON.stringify({
@@ -136,7 +142,7 @@ describe('SyncPage sync trigger', () => {
     // Already synced: a first-sync mismatch is now auto-plugged rather than
     // left as a standing mismatch, so this steady-state UI check needs an
     // account past its first sync to exercise the mismatch path at all.
-    await writeWatermark(host.api, 'ACT-1', { lastPosted: 1700000000 - 86_400, recentIds: [] });
+    await writeWatermark(host.api, 'WF-1', { lastPosted: 1700000000 - 86_400, recentIds: [] });
     host.respond(/\/accounts/, {
       body: JSON.stringify({
         accounts: [
@@ -153,7 +159,10 @@ describe('SyncPage sync trigger', () => {
         errors: [],
       }),
     });
-    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', name: 'My Checking', balance: 100 }] as never);
+    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', name: 'My Checking' }] as never);
+    host.api.portfolio.getLatestValuations = vi.fn(async () => [
+      { accountId: 'WF-1', cashBalance: 100 },
+    ] as never);
 
     render(<SyncPage api={host.api} />);
     await screen.findByText('Checking');
@@ -199,6 +208,9 @@ describe('SyncPage sync trigger', () => {
   it('renders history newest-first after a completed run', async () => {
     const host = createMockHost();
     seedConfig(host, [CHECKING_MAPPING]);
+    // Not testing first-sync backfill here — mark it already synced so the
+    // opening-balance plug doesn't affect the imported count.
+    await writeWatermark(host.api, 'WF-1', { lastPosted: 1700000000 - 86_400, recentIds: [] });
     await appendRun(host.api, {
       startedAt: '2026-01-01T00:00:00.000Z',
       finishedAt: '2026-01-01T00:00:01.000Z',

--- a/src/test/mockHost.ts
+++ b/src/test/mockHost.ts
@@ -51,7 +51,7 @@ export function createMockHost(): MockHost {
       })),
     },
     snapshots: { checkImport: vi.fn(), importSnapshots: vi.fn() },
-    portfolio: { recalculate: vi.fn(async () => {}) },
+    portfolio: { recalculate: vi.fn(async () => {}), getLatestValuations: vi.fn(async () => []) },
     logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn(), trace: vi.fn() },
   } as unknown as HostAPI;
 


### PR DESCRIPTION
## Summary

The opening-balance backfill feature (#48) looked done and passed all unit tests, but manual testing against a real, running Wealthfolio host turned up four compounding defects that made it either non-functional or subtly wrong:

- **Missing permission**: `manifest.json` never declared `portfolio.recalculate`, so the host silently blocked the call and the whole first-sync path aborted before it could plug anything.
- **Wrong watermark key**: the sync watermark was keyed by `sfAccountId` instead of `wfAccountId`. Remapping a SimpleFIN account to a fresh Wealthfolio account (e.g. delete + recreate) incorrectly inherited "already synced" state from the old destination.
- **Date range too wide**: the first-sync history pull requested `start-date=0` (epoch), which exceeds the SimpleFIN Bridge's recommended 45-day range and comes back with an advisory error. Capped at 40 days — safe, since the opening-balance plug already covers whatever real history falls outside that window.
- **Wrong balance source, then a race**: `Account.balance` from `accounts.getAll()` isn't populated at all on this host (confirmed directly against the live API), so both the plug and the balance-mismatch diagnostic were switched to `portfolio.getLatestValuations().cashBalance`. That in turn surfaced a race — `recalculate()` resolving doesn't guarantee an immediately-following `getLatestValuations()` reflects what this same run just imported (confirmed live: it read the stale pre-import balance and doubled the plug). The plug is now computed deterministically from the pre-sync balance snapshot plus the signed sum of this run's own imports, with no host read-back in the critical path.

## Test plan

- [x] Unit tests updated/added for the watermark rekey, the capped date range, the `getLatestValuations`-based balance sources, and a regression test pinning the race-condition fix
- [x] `pnpm test` — 170 passed
- [x] `pnpm type-check` — clean
- [x] Verified end-to-end against a running Wealthfolio container: a genuine first sync now creates the correct `TRANSFER_IN`/`TRANSFER_OUT` "Opening balance (SimpleFIN migration)" activity and the resulting balance matches SimpleFIN's reported balance exactly

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)