### PR TITLE
fix: link reclassified transfers via sourceGroupId instead of update()

### DIFF
--- a/docs/superpowers/plans/2026-08-26-backfill-relink-unlinked-transfers.md
+++ b/docs/superpowers/plans/2026-08-26-backfill-relink-unlinked-transfers.md
@@ -1,0 +1,580 @@
+# Backfill-Relink Pre-Existing Unlinked Transfer Pairs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Find `TRANSFER_IN`/`TRANSFER_OUT` activities reclassified before `sourceGroupId` linking existed and relink unambiguous 1:1 matches, so Wealthfolio's Data Consistency checker stops flagging them — without touching the live sync path.
+
+**Architecture:** A new `relinkUnlinkedTransferPairs` function (`src/lib/sync/reconciliation.ts`) searches already-typed `TRANSFER_IN`/`TRANSFER_OUT` activities missing `sourceGroupId`, matches them pairwise by reusing the existing `withdrawalMatches` logic (generalized to accept a narrower shape than a full `StagedCandidate`), and relinks unambiguous matches via the existing `reclassifyPair`. It's wired into the existing "Scan for older payments and transfers" button (`StagedTransactionsList.tsx`) rather than run automatically on every sync, since it operates on activities that can be arbitrarily older than the ~7-day window live candidates ever reach.
+
+**Tech Stack:** TypeScript, Vitest, React Testing Library, `@wealthfolio/addon-sdk`.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-backfill-relink-unlinked-transfers-design.md`
+
+## Global Constraints
+
+- No new UI for ambiguous matches — count them, leave the pair alone, never stage them.
+- Never call `relinkUnlinkedTransferPairs` from `runSync` or any automatic path — manual "Scan" button only.
+- `sourceGroupId` for a relinked pair is the `TRANSFER_IN` row's own `id` (same "reuse the deleted row's own id" precedent already used for backfilled candidates in `findBackfillCandidatesOfType`).
+- Reuse `reclassifyPair` unchanged — do not duplicate its delete+recreate logic.
+
+---
+
+### Task 1: `relinkUnlinkedTransferPairs` in `reconciliation.ts`
+
+**Files:**
+- Modify: `src/lib/sync/reconciliation.ts:93-106` (generalize `withdrawalMatches`), append new code after line 377 (end of file)
+- Test: `src/lib/sync/reconciliation.test.ts` (new `describe('relinkUnlinkedTransferPairs', ...)` block)
+
+**Interfaces:**
+- Consumes: `searchAllByType`, `reclassifyPair`, `toIsoDateOnly`, `normalise`, `MATCH_WINDOW_DAYS`, `SECONDS_PER_DAY` — all already in this file.
+- Produces: `export async function relinkUnlinkedTransferPairs(api: HostAPI, inflowAccountIds: string[], cashAccountIds: string[]): Promise<RelinkSummary>` where `RelinkSummary = { relinked: number; ambiguous: number }` — Task 2 calls this directly.
+
+- [ ] **Step 1: Generalize `withdrawalMatches` to accept a `MatchTarget` instead of a full `StagedCandidate`**
+
+Replace lines 79-106 of `src/lib/sync/reconciliation.ts`:
+
+```ts
+/**
+ * Filters an already-fetched withdrawal pool down to this candidate's
+ * matches (same amount, posted within the match window, in an account other
+ * than the candidate's own inflow account). Pure and synchronous on purpose
+ * — the withdrawal pool is identical for every candidate in a run, so
+ * callers fetch it once via `searchAllByType` and reuse it across
+ * candidates rather than re-fetching per candidate.
+ *
+ * The same-account exclusion matters only for a cash-to-cash transfer
+ * candidate — its own account is part of the withdrawal search pool, unlike
+ * a credit-card candidate's account, which `cashAccountIdsFrom` already
+ * excludes from that pool. Without it, a transfer's destination account
+ * could match a withdrawal sitting in that very account.
+ */
+function withdrawalMatches(withdrawals: ActivityDetails[], candidate: StagedCandidate): ActivityDetails[] {
+  const inflowPostedSeconds = Date.parse(candidate.postedDate) / 1000;
+  const windowStartSeconds = inflowPostedSeconds - MATCH_WINDOW_DAYS * SECONDS_PER_DAY;
+
+  return withdrawals.filter((w) => {
+    if (w.accountId === candidate.inflowAccountId) return false;
+    const postedSeconds = Date.parse(toIsoDateOnly(w.date)) / 1000;
+    return (
+      normalise(w.amount ?? '0') === normalise(candidate.amount) &&
+      postedSeconds >= windowStartSeconds &&
+      postedSeconds <= inflowPostedSeconds
+    );
+  });
+}
+```
+
+with:
+
+```ts
+/**
+ * The subset of a candidate's fields `withdrawalMatches` actually needs —
+ * lets a non-candidate caller (`relinkUnlinkedTransferPairs`) reuse the same
+ * matching logic without constructing a full `StagedCandidate`.
+ */
+type MatchTarget = Pick<StagedCandidate, 'inflowAccountId' | 'amount' | 'postedDate'>;
+
+/**
+ * Filters an already-fetched withdrawal pool down to this target's matches
+ * (same amount, posted within the match window, in an account other than
+ * the target's own inflow account). Pure and synchronous on purpose — the
+ * withdrawal pool is identical for every candidate in a run, so callers
+ * fetch it once via `searchAllByType` and reuse it across candidates rather
+ * than re-fetching per candidate.
+ *
+ * The same-account exclusion matters only for a cash-to-cash transfer
+ * candidate — its own account is part of the withdrawal search pool, unlike
+ * a credit-card candidate's account, which `cashAccountIdsFrom` already
+ * excludes from that pool. Without it, a transfer's destination account
+ * could match a withdrawal sitting in that very account.
+ */
+function withdrawalMatches(withdrawals: ActivityDetails[], target: MatchTarget): ActivityDetails[] {
+  const inflowPostedSeconds = Date.parse(target.postedDate) / 1000;
+  const windowStartSeconds = inflowPostedSeconds - MATCH_WINDOW_DAYS * SECONDS_PER_DAY;
+
+  return withdrawals.filter((w) => {
+    if (w.accountId === target.inflowAccountId) return false;
+    const postedSeconds = Date.parse(toIsoDateOnly(w.date)) / 1000;
+    return (
+      normalise(w.amount ?? '0') === normalise(target.amount) &&
+      postedSeconds >= windowStartSeconds &&
+      postedSeconds <= inflowPostedSeconds
+    );
+  });
+}
+```
+
+(This is a pure signature generalization — `runReconciliation`'s existing call site at line ~327, `withdrawalMatches(withdrawals, candidate)`, needs no change: a `StagedCandidate` already structurally satisfies `MatchTarget`.)
+
+- [ ] **Step 2: Run the existing suite to confirm the generalization is behavior-preserving**
+
+Run: `pnpm test -- reconciliation.test.ts`
+Expected: PASS — all existing tests in this file still pass unchanged (no behavior change yet, just a type generalization).
+
+- [ ] **Step 3: Append `sourceGroupIdOf`, `RelinkSummary`, and `relinkUnlinkedTransferPairs` to the end of `src/lib/sync/reconciliation.ts`**
+
+Append after the current last line (377, the closing brace of `resolveAmbiguous`):
+
+```ts
+
+/**
+ * `sourceGroupId` is on the host's `Activity` model but missing from the
+ * SDK's `ActivityDetails` type — confirmed present in the runtime JSON
+ * regardless (2026-08-26 live probe, see the design doc). This cast is the
+ * one place that gap is bridged; every other read goes through this
+ * function.
+ */
+function sourceGroupIdOf(row: ActivityDetails): string | null {
+  return ((row as unknown as Record<string, unknown>).sourceGroupId as string | null | undefined) ?? null;
+}
+
+export interface RelinkSummary {
+  relinked: number;
+  ambiguous: number;
+}
+
+/**
+ * Finds `TRANSFER_IN`/`TRANSFER_OUT` activities reclassified before
+ * `sourceGroupId` linking existed (or by any other means that left them
+ * unlinked) and relinks unambiguous 1:1 matches via `reclassifyPair`.
+ *
+ * Deliberately does not surface ambiguous matches for manual resolution the
+ * way live candidates do — every existing pair here was created by a past
+ * *unambiguous* match (that's the only way `reclassifyPair` is ever
+ * called), so re-deriving that same match now should essentially never
+ * produce ambiguity. `ambiguous` is counted so a caller can still report it,
+ * but the pair is simply left alone rather than staged.
+ */
+export async function relinkUnlinkedTransferPairs(
+  api: HostAPI,
+  inflowAccountIds: string[],
+  cashAccountIds: string[],
+): Promise<RelinkSummary> {
+  if (inflowAccountIds.length === 0 || cashAccountIds.length === 0) {
+    return { relinked: 0, ambiguous: 0 };
+  }
+
+  const [transferIns, transferOuts] = await Promise.all([
+    searchAllByType(api, inflowAccountIds, 'TRANSFER_IN'),
+    searchAllByType(api, cashAccountIds, 'TRANSFER_OUT'),
+  ]);
+  const unlinkedIns = transferIns.filter((r) => !sourceGroupIdOf(r));
+  const unlinkedOuts = transferOuts.filter((r) => !sourceGroupIdOf(r));
+
+  let relinked = 0;
+  let ambiguous = 0;
+  const claimedOutIds = new Set<string>();
+
+  for (const inRow of unlinkedIns) {
+    const target: MatchTarget = {
+      inflowAccountId: inRow.accountId,
+      amount: inRow.amount ?? '0',
+      postedDate: toIsoDateOnly(inRow.date),
+    };
+    const matches = withdrawalMatches(unlinkedOuts, target).filter((o) => !claimedOutIds.has(o.id));
+
+    if (matches.length === 0) continue;
+    if (matches.length > 1) {
+      ambiguous += 1;
+      continue;
+    }
+
+    try {
+      await reclassifyPair(api, inRow, matches[0], inRow.id);
+      claimedOutIds.add(matches[0].id);
+      relinked += 1;
+    } catch (error) {
+      api.logger.error(`[simplefin] relink failed for TRANSFER_IN ${inRow.id}: ${String(error)}`);
+    }
+  }
+
+  return { relinked, ambiguous };
+}
+```
+
+- [ ] **Step 4: Add tests to `src/lib/sync/reconciliation.test.ts`**
+
+Add fixture helpers near the top of the file, alongside the existing `cardActivity`/`withdrawalActivity` helpers:
+
+```ts
+const transferInActivity = (over: Partial<ActivityDetails> & { sourceGroupId?: string | null } = {}): ActivityDetails =>
+  ({
+    id: 'TIN-1',
+    accountId: 'WF-CARD',
+    activityType: 'TRANSFER_IN',
+    date: '2025-08-06T00:00:00+00:00',
+    amount: '50',
+    currency: 'USD',
+    comment: 'Old payment',
+    sourceGroupId: null,
+    ...over,
+  }) as ActivityDetails;
+
+const transferOutActivity = (over: Partial<ActivityDetails> & { sourceGroupId?: string | null } = {}): ActivityDetails =>
+  ({
+    id: 'TOUT-1',
+    accountId: 'WF-CASH',
+    activityType: 'TRANSFER_OUT',
+    date: '2025-08-05T00:00:00+00:00',
+    amount: '50',
+    currency: 'USD',
+    comment: 'Old withdrawal',
+    sourceGroupId: null,
+    ...over,
+  }) as ActivityDetails;
+```
+
+Add this import to the top of the file: `relinkUnlinkedTransferPairs` alongside the other named imports from `./reconciliation`.
+
+Add a new `describe` block (anywhere after the existing ones, e.g. at the end of the file):
+
+```ts
+describe('relinkUnlinkedTransferPairs', () => {
+  it('relinks an unambiguous unlinked pair via saveMany, using the TRANSFER_IN id as sourceGroupId', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') return { data: [transferInActivity()], meta: { totalRowCount: 1 } };
+      if (filters.activityTypes === 'TRANSFER_OUT') return { data: [transferOutActivity()], meta: { totalRowCount: 1 } };
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
+
+    expect(result).toEqual({ relinked: 1, ambiguous: 0 });
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TIN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TIN-1' }),
+      ],
+      deleteIds: ['TIN-1', 'TOUT-1'],
+    });
+  });
+
+  it('excludes a row that already has sourceGroupId set from matching entirely', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') {
+        return { data: [transferInActivity({ sourceGroupId: 'already-linked' })], meta: { totalRowCount: 1 } };
+      }
+      if (filters.activityTypes === 'TRANSFER_OUT') return { data: [transferOutActivity()], meta: { totalRowCount: 1 } };
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
+
+    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(host.api.activities.saveMany).not.toHaveBeenCalled();
+  });
+
+  it('leaves a TRANSFER_IN with zero withdrawal matches unlinked', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') return { data: [transferInActivity()], meta: { totalRowCount: 1 } };
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
+
+    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(host.api.activities.saveMany).not.toHaveBeenCalled();
+  });
+
+  it('counts ambiguous and does not call saveMany when 2+ matches exist for a row', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') return { data: [transferInActivity()], meta: { totalRowCount: 1 } };
+      if (filters.activityTypes === 'TRANSFER_OUT') {
+        return {
+          data: [transferOutActivity(), transferOutActivity({ id: 'TOUT-2', accountId: 'WF-CASH-2' })],
+          meta: { totalRowCount: 2 },
+        };
+      }
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH', 'WF-CASH-2']);
+
+    expect(result).toEqual({ relinked: 0, ambiguous: 1 });
+    expect(host.api.activities.saveMany).not.toHaveBeenCalled();
+  });
+
+  it("isolates a per-row failure so a later row still relinks", async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') {
+        return {
+          data: [transferInActivity({ id: 'TIN-BAD' }), transferInActivity({ id: 'TIN-GOOD' })],
+          meta: { totalRowCount: 2 },
+        };
+      }
+      if (filters.activityTypes === 'TRANSFER_OUT') {
+        return {
+          data: [transferOutActivity({ id: 'TOUT-BAD' }), transferOutActivity({ id: 'TOUT-GOOD' })],
+          meta: { totalRowCount: 2 },
+        };
+      }
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+    host.api.activities.saveMany = vi.fn(async (req: { deleteIds?: string[] }) => {
+      if (req.deleteIds?.includes('TIN-BAD')) {
+        return { created: [], updated: [], deleted: [], createdMappings: [], errors: [{ id: 'TIN-BAD', action: 'create', message: 'boom' }] };
+      }
+      return { created: [], updated: [], deleted: [], createdMappings: [], errors: [] };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
+
+    expect(result.relinked).toBe(1);
+    expect(host.api.logger.error).toHaveBeenCalledWith(expect.stringContaining('TIN-BAD'));
+  });
+
+  it('returns zero counts without searching when inflowAccountIds is empty', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn();
+
+    const result = await relinkUnlinkedTransferPairs(host.api, [], ['WF-CASH']);
+
+    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(host.api.activities.search).not.toHaveBeenCalled();
+  });
+
+  it('returns zero counts without searching when cashAccountIds is empty', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn();
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], []);
+
+    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(host.api.activities.search).not.toHaveBeenCalled();
+  });
+});
+```
+
+Note the two `transferOutActivity({ id: 'TOUT-BAD' })`/`transferOutActivity({ id: 'TOUT-GOOD' })` fixtures in the isolation test both default to `accountId: 'WF-CASH'` and the same `date`/`amount` as the two TRANSFER_IN rows — since both TRANSFER_IN rows also share the same amount/date by default, each independently matches both TRANSFER_OUT rows unless claimed. Verify while implementing that `TIN-BAD` and `TIN-GOOD` don't cross-match each other's intended partner ambiguously — if the test as written produces `ambiguous` instead of one clean success and one clean failure, adjust the fixtures' `id`s only (keep amounts/dates matching, differentiate accounts if needed, e.g. give `TOUT-GOOD`/`TIN-GOOD` a different `accountId` pair like `WF-CASH-2`) so each TRANSFER_IN has exactly one matching TRANSFER_OUT.
+
+- [ ] **Step 5: Run the full suite and type-check**
+
+Run: `pnpm test && pnpm type-check`
+Expected: PASS — all tests pass (existing + new), no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/sync/reconciliation.ts src/lib/sync/reconciliation.test.ts
+git commit -m "feat: add relinkUnlinkedTransferPairs to backfill sourceGroupId onto pre-existing transfer pairs"
+```
+
+---
+
+### Task 2: Wire `relinkUnlinkedTransferPairs` into the Staged Transactions "Scan" button
+
+**Files:**
+- Modify: `src/components/StagedTransactionsList.tsx`
+- Test: `src/components/StagedTransactionsList.test.tsx`
+
+**Interfaces:**
+- Consumes: `relinkUnlinkedTransferPairs(api, inflowAccountIds, cashAccountIds): Promise<RelinkSummary>` from Task 1.
+- Produces: nothing new for other tasks — this is the final consumer.
+
+- [ ] **Step 1: Import `relinkUnlinkedTransferPairs` and add result-summary state**
+
+In `src/components/StagedTransactionsList.tsx`, change the import line:
+
+```ts
+import { describeWithdrawals, findBackfillCandidates, resolveAmbiguous, runReconciliation } from '../lib/sync/reconciliation';
+```
+
+to:
+
+```ts
+import { describeWithdrawals, findBackfillCandidates, relinkUnlinkedTransferPairs, resolveAmbiguous, runReconciliation } from '../lib/sync/reconciliation';
+```
+
+Add a new state variable next to `const [scanning, setScanning] = useState(false);`:
+
+```ts
+  const [scanResult, setScanResult] = useState<string | null>(null);
+```
+
+- [ ] **Step 2: Extend `scanForOlderPayments` to also relink and report both counts**
+
+Replace the current `scanForOlderPayments` function body:
+
+```ts
+  async function scanForOlderPayments() {
+    setError(null);
+    setScanning(true);
+    try {
+      const existing = await readStaging(api);
+      const found = await findBackfillCandidates(api, cardAccountIds, paymentKeywords, cashAccountIds, transferKeywords, existing);
+      const { candidates: remaining } = await runReconciliation(
+        api,
+        [...existing, ...found],
+        cashAccountIds,
+        Math.floor(Date.now() / 1000),
+      );
+      setCandidates(remaining);
+      await writeStaging(api, remaining);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setScanning(false);
+    }
+  }
+```
+
+with:
+
+```ts
+  async function scanForOlderPayments() {
+    setError(null);
+    setScanResult(null);
+    setScanning(true);
+    try {
+      const existing = await readStaging(api);
+      const found = await findBackfillCandidates(api, cardAccountIds, paymentKeywords, cashAccountIds, transferKeywords, existing);
+      const { candidates: remaining } = await runReconciliation(
+        api,
+        [...existing, ...found],
+        cashAccountIds,
+        Math.floor(Date.now() / 1000),
+      );
+      setCandidates(remaining);
+      await writeStaging(api, remaining);
+
+      const { relinked, ambiguous } = await relinkUnlinkedTransferPairs(api, [...cardAccountIds, ...cashAccountIds], cashAccountIds);
+      setScanResult(
+        `Found ${found.length} new candidate${found.length === 1 ? '' : 's'}. Relinked ${relinked} pair${relinked === 1 ? '' : 's'}, ${ambiguous} ambiguous.`,
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setScanning(false);
+    }
+  }
+```
+
+- [ ] **Step 3: Update the button label and render the result text**
+
+Replace:
+
+```ts
+  const scanButton = (
+    <Button size="sm" variant="outline" onClick={scanForOlderPayments} disabled={scanning}>
+      {scanning ? 'Scanning…' : 'Scan for older payments and transfers'}
+    </Button>
+  );
+```
+
+with:
+
+```ts
+  const scanButton = (
+    <div className="flex flex-col gap-1">
+      <Button size="sm" variant="outline" onClick={scanForOlderPayments} disabled={scanning}>
+        {scanning ? 'Scanning…' : 'Scan for older payments, transfers, and unlinked pairs'}
+      </Button>
+      {scanResult && <p className="text-muted-foreground text-sm">{scanResult}</p>}
+    </div>
+  );
+```
+
+- [ ] **Step 4: Add a test exercising the relink wiring**
+
+Add this test to `src/components/StagedTransactionsList.test.tsx`, in the main `describe('StagedTransactionsList', ...)` block, near the other scan tests:
+
+```ts
+  it('relinks unlinked transfer pairs found during a scan and reports the count', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') {
+        return {
+          data: [
+            {
+              id: 'OLD-TIN-1',
+              accountId: 'WF-CARD',
+              activityType: 'TRANSFER_IN',
+              date: '2025-08-06T00:00:00+00:00',
+              amount: '50',
+              currency: 'USD',
+              comment: 'Old payment',
+            },
+          ],
+          meta: { totalRowCount: 1 },
+        };
+      }
+      if (filters.activityTypes === 'TRANSFER_OUT') {
+        return {
+          data: [
+            {
+              id: 'OLD-TOUT-1',
+              accountId: 'WF-CASH',
+              activityType: 'TRANSFER_OUT',
+              date: '2025-08-05T00:00:00+00:00',
+              amount: '50',
+              currency: 'USD',
+              comment: 'Old withdrawal',
+            },
+          ],
+          meta: { totalRowCount: 1 },
+        };
+      }
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    render(<StagedTransactionsList api={host.api} {...defaultProps} />);
+    await screen.findByText(/no staged transactions/i);
+
+    await userEvent.click(screen.getByRole('button', { name: /scan for older payments/i }));
+
+    expect(await screen.findByText(/relinked 1 pair/i)).toBeInTheDocument();
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'OLD-TIN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'OLD-TIN-1' }),
+      ],
+      deleteIds: ['OLD-TIN-1', 'OLD-TOUT-1'],
+    });
+  });
+```
+
+- [ ] **Step 5: Verify the two existing scan tests still pass unchanged**
+
+Run: `pnpm test -- StagedTransactionsList.test.tsx`
+
+The two pre-existing tests named `'scans existing activities and stages a keyword match with no withdrawal pair yet'` and `'immediately resolves a scanned candidate when a matching withdrawal already exists'` should still pass without modification — their `search` mocks only branch on `filters.activityTypes === 'CREDIT'` vs. an else-branch, so the new `TRANSFER_IN`/`TRANSFER_OUT` searches this task adds fall into that else-branch. In the second test specifically, the else-branch happens to return a `WITHDRAWAL`-typed fixture on account `WF-CASH` regardless of the requested type — trace through `relinkUnlinkedTransferPairs`'s matching logic for that fixture value (`accountId: 'WF-CASH'`) against the target it would build from that same fixture treated as a `TRANSFER_IN` result (also `accountId: 'WF-CASH'`): the same-account exclusion in `withdrawalMatches` should exclude it from matching itself, producing zero matches and no extra `saveMany` call. Confirm this by reading the test output rather than assuming — if either test fails or produces an unexpected extra `saveMany` call, do not weaken assertions to force a pass; report BLOCKED with what you saw so the mock (or this plan) can be fixed with fresh eyes, since this is a coincidental interaction the plan predicted but did not want to weaken safety on.
+
+Expected: PASS — all tests in this file pass, both pre-existing and the new one from Step 4.
+
+- [ ] **Step 6: Run the full suite and type-check**
+
+Run: `pnpm test && pnpm type-check`
+Expected: PASS — everything green, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/StagedTransactionsList.tsx src/components/StagedTransactionsList.test.tsx
+git commit -m "feat: wire relink into the Scan button and surface the result count"
+```
+
+---
+
+### Task 3: Manual verification against the live e2e host
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build and package**
+
+Run: `pnpm bundle`
+Expected: `dist/simplefin-wealthfolio-addon-1.0.0.zip` produced with no build errors.
+
+- [ ] **Step 2: Install into `wealthfolio-e2e` (or hand the zip to the user)**
+
+Same install flow as the prior plan's Task 3: Settings → Add-ons → "+" → "Install from File". If driving this via browser automation, expect the same sandboxed-iframe input limitation already documented in `docs/superpowers/plans/2026-08-26-sourcegroupid-transfer-linking.md`'s Task 3 — if clicks don't register inside the addon's own tab content, hand the zip to the user instead of attempting further automation workarounds.
+
+- [ ] **Step 3: Click "Scan for older payments, transfers, and unlinked pairs" and confirm the result text**
+
+Expected: the result line under the button shows a non-negative `relinked` count, and any of the 28 originally-flagged transfer pairs that had an unambiguous match no longer appear as incomplete in Wealthfolio's Data Consistency check.
+
+- [ ] **Step 4: No commit** — this task is verification only, nothing to commit.

--- a/docs/superpowers/plans/2026-08-26-sourcegroupid-transfer-linking.md
+++ b/docs/superpowers/plans/2026-08-26-sourcegroupid-transfer-linking.md
@@ -1,0 +1,349 @@
+# Link Reclassified Transfers via sourceGroupId Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `reclassifyPair()` link both legs of a reconciled transfer via `sourceGroupId` so Wealthfolio's Data Consistency checker stops flagging them as incomplete.
+
+**Architecture:** `reclassifyPair()` (`src/lib/sync/reconciliation.ts`) currently reclassifies both legs in place via `activities.saveMany({ updates: [...] })`. A live-host probe confirmed `update()` silently drops `sourceGroupId` but `saveMany({ creates: [...] })` persists it. The fix switches `reclassifyPair()` to delete both original legs and recreate them as `TRANSFER_IN`/`TRANSFER_OUT` with `sourceGroupId` set to the candidate's `sfTransactionId`, in one `saveMany` call.
+
+**Tech Stack:** TypeScript, Vitest, `@wealthfolio/addon-sdk` (`ActivityCreate`, `saveMany`).
+
+**Spec:** `docs/superpowers/specs/2026-08-26-sourcegroupid-transfer-linking-design.md`
+
+## Global Constraints
+
+- No manifest change — `saveMany({ creates, deleteIds })` works under the already-declared `saveMany` permission (confirmed live); do not add `create` to `manifest.json`.
+- `sourceGroupId` value is the candidate's existing `sfTransactionId` — do not generate a new id.
+- Both legs must be created and deleted in a single `saveMany` call (same split-write rationale as the code being replaced).
+- `resolveAmbiguous()` is not touched directly — it already delegates to `reclassifyPair()`.
+
+---
+
+### Task 1: Extend the mock host's `saveMany` to support `creates`/`deleteIds`
+
+**Files:**
+- Modify: `src/test/mockHost.ts:45-51`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `host.api.activities.saveMany` now echoes `req.creates` into `result.created` (each entry assigned a synthetic id) in addition to the existing `req.updates` → `result.updated` echo, and `req.deleteIds` into `result.deleted`. Task 2/3 rely on this to exercise the new `reclassifyPair()` without every test needing its own `saveMany` mock.
+
+- [ ] **Step 1: Replace the `saveMany` mock**
+
+Replace lines 45-51 of `src/test/mockHost.ts`:
+
+```ts
+      saveMany: vi.fn(async (req: { updates?: unknown[] }) => ({
+        created: [],
+        updated: req.updates ?? [],
+        deleted: [],
+        createdMappings: [],
+        errors: [],
+      })),
+```
+
+with:
+
+```ts
+      saveMany: vi.fn(async (req: { creates?: unknown[]; updates?: unknown[]; deleteIds?: string[] }) => ({
+        created: (req.creates ?? []).map((c, i) => ({ id: `MOCK-CREATED-${i}`, ...(c as object) })),
+        updated: req.updates ?? [],
+        deleted: req.deleteIds ?? [],
+        createdMappings: [],
+        errors: [],
+      })),
+```
+
+- [ ] **Step 2: Run the existing suite to confirm nothing broke**
+
+Run: `pnpm test`
+Expected: PASS — all 202 existing tests still pass (this step is purely additive; no test yet exercises `creates`/`deleteIds`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/test/mockHost.ts
+git commit -m "test: mock host saveMany echoes creates/deleteIds"
+```
+
+---
+
+### Task 2: Switch `reclassifyPair()` to delete+recreate with `sourceGroupId`
+
+**Files:**
+- Modify: `src/lib/sync/reconciliation.ts:1` (import), `src/lib/sync/reconciliation.ts:184-232` (`toUpdate`/`reclassifyPair`)
+- Modify: `src/lib/sync/reconciliation.test.ts:66-71,104-109,632-637,666-671` (the four assertions on `saveMany`'s exact call shape)
+
+**Interfaces:**
+- Consumes: `StagedCandidate.sfTransactionId` (existing field, used as the new `sourceGroupId`).
+- Produces: `reclassifyPair(api, inflowRow, withdrawalRow, sfTransactionId)` — same signature as before, same callers (`runReconciliation`, `resolveAmbiguous`), no changes needed at either call site.
+
+- [ ] **Step 1: Update the four `saveMany` assertions to expect the new shape (failing first)**
+
+In `src/lib/sync/reconciliation.test.ts`, replace each of the four occurrences of this pattern (lines 66-71 and 104-109 in the `runReconciliation` describe block, and lines 632-637 and 666-671 in the `resolveAmbiguous` describe block):
+
+Occurrence 1 (`'resolves a unique match by reclassifying both legs'`, currently lines 66-71):
+
+```ts
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      updates: [
+        expect.objectContaining({ id: 'CARD-ACT-1', activityType: 'TRANSFER_IN' }),
+        expect.objectContaining({ id: 'CASH-ACT-1', activityType: 'TRANSFER_OUT' }),
+      ],
+    });
+```
+
+becomes:
+
+```ts
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-1' }),
+      ],
+      deleteIds: ['CARD-ACT-1', 'CASH-ACT-1'],
+    });
+```
+
+Occurrence 2 (`'resolves a cash-to-cash transfer candidate (DEPOSIT inflow) the same way'`, currently lines 104-109):
+
+```ts
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      updates: [
+        expect.objectContaining({ id: 'DEPOSIT-ACT-1', activityType: 'TRANSFER_IN' }),
+        expect.objectContaining({ id: 'CASH-ACT-1', activityType: 'TRANSFER_OUT' }),
+      ],
+    });
+```
+
+becomes:
+
+```ts
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CASH-B', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH-A', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-1' }),
+      ],
+      deleteIds: ['DEPOSIT-ACT-1', 'CASH-ACT-1'],
+    });
+```
+
+Occurrence 3 (in `describe('resolveAmbiguous', ...)`, `'reclassifies the chosen withdrawal and the resolved inflow activity'`, currently lines 632-637):
+
+```ts
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      updates: [
+        expect.objectContaining({ id: 'CARD-ACT-1', activityType: 'TRANSFER_IN' }),
+        expect.objectContaining({ id: 'CASH-ACT-1', activityType: 'TRANSFER_OUT' }),
+      ],
+    });
+```
+
+becomes:
+
+```ts
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-1' }),
+      ],
+      deleteIds: ['CARD-ACT-1', 'CASH-ACT-1'],
+    });
+```
+
+Occurrence 4 (`'reclassifies the chosen withdrawal and the resolved deposit activity for a cash-transfer candidate'`, currently lines 666-671):
+
+```ts
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      updates: [
+        expect.objectContaining({ id: 'DEPOSIT-ACT-1', activityType: 'TRANSFER_IN' }),
+        expect.objectContaining({ id: 'CASH-ACT-1', activityType: 'TRANSFER_OUT' }),
+      ],
+    });
+```
+
+becomes:
+
+```ts
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CASH-B', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-1' }),
+      ],
+      deleteIds: ['DEPOSIT-ACT-1', 'CASH-ACT-1'],
+    });
+```
+
+- [ ] **Step 2: Run the suite to confirm these four tests now fail**
+
+Run: `pnpm test -- reconciliation.test.ts`
+Expected: FAIL — exactly these 4 tests fail, each showing `saveMany` was called with `{ updates: [...] }` (old shape) instead of the expected `{ creates: [...], deleteIds: [...] }`. All other tests in the file still pass.
+
+- [ ] **Step 3: Update the import**
+
+In `src/lib/sync/reconciliation.ts`, line 1, replace:
+
+```ts
+import type { ActivityDetails, ActivityUpdate, HostAPI } from '@wealthfolio/addon-sdk';
+```
+
+with:
+
+```ts
+import type { ActivityCreate, ActivityDetails, HostAPI } from '@wealthfolio/addon-sdk';
+```
+
+- [ ] **Step 4: Replace `toUpdate`/`reclassifyPair` with `toCreate`/`reclassifyPair`**
+
+In `src/lib/sync/reconciliation.ts`, replace lines 184-232 (the `toUpdate` function, its preceding blank line, the `reclassifyPair` doc comment, and the `reclassifyPair` function):
+
+```ts
+function toUpdate(row: ActivityDetails, activityType: string): ActivityUpdate {
+  return {
+    id: row.id,
+    accountId: row.accountId,
+    activityType,
+    activityDate: row.date,
+    amount: row.amount,
+    currency: row.currency,
+    comment: row.comment,
+  };
+}
+
+/**
+ * `sourceGroupId` is deliberately not set here — confirmed against a live
+ * host that `activities.update()` doesn't persist it, so there is no
+ * host-side visual pairing available; the two legs are linked only by the
+ * staging record until it's dropped.
+ *
+ * Both legs are sent in a single `saveMany()` call rather than two
+ * sequential `update()` calls: `findInflowActivity()` only ever searches
+ * `candidate.inflowActivityType`, so if the inflow leg alone were
+ * reclassified to `TRANSFER_IN` and the withdrawal leg's write then failed,
+ * the next reconciliation attempt could never re-find the (now
+ * non-CREDIT/DEPOSIT) inflow activity — leaving the pair permanently
+ * half-reclassified. One request, one failure path avoids that split-write
+ * state.
+ *
+ * `saveMany` can also resolve successfully while still reporting a per-item
+ * failure in `result.errors` rather than throwing — that's checked here and
+ * turned into a thrown error so the caller's existing catch/retry path (in
+ * `runReconciliation`) treats it the same as a hard failure, instead of
+ * counting the candidate resolved while one or both legs never actually
+ * changed.
+ */
+async function reclassifyPair(
+  api: HostAPI,
+  inflowRow: ActivityDetails,
+  withdrawalRow: ActivityDetails,
+  sfTransactionId: string,
+): Promise<void> {
+  const result = await api.activities.saveMany({
+    updates: [toUpdate(inflowRow, 'TRANSFER_IN'), toUpdate(withdrawalRow, 'TRANSFER_OUT')],
+  });
+  if (result.errors.length > 0) {
+    throw new Error(
+      `saveMany reported per-item errors for candidate ${sfTransactionId}: ${JSON.stringify(result.errors)}`,
+    );
+  }
+}
+```
+
+with:
+
+```ts
+function toCreate(row: ActivityDetails, activityType: string, sourceGroupId: string): ActivityCreate {
+  return {
+    accountId: row.accountId,
+    activityType,
+    activityDate: row.date,
+    amount: row.amount,
+    currency: row.currency,
+    comment: row.comment,
+    sourceGroupId,
+  };
+}
+
+/**
+ * Reclassifying via `activities.update()` was tried first (see the
+ * 2026-08-14 design doc) and confirmed against a live host to silently drop
+ * `sourceGroupId` — the two legs ended up correctly typed but never linked,
+ * which is invisible to `update()` but visible to Wealthfolio's own Data
+ * Consistency checker. A follow-up live-host probe (2026-08-26) confirmed
+ * `saveMany({ creates: [...] })` does persist it, so both legs are deleted
+ * and recreated instead of updated in place, linked by the candidate's own
+ * `sfTransactionId` as a shared `sourceGroupId`.
+ *
+ * Both legs are still created/deleted in a single `saveMany()` call rather
+ * than sequential calls, for the same reason as before: `findInflowActivity()`
+ * only ever searches `candidate.inflowActivityType`, so if the inflow leg
+ * alone were recreated as `TRANSFER_IN` and the withdrawal leg's write then
+ * failed, the next reconciliation attempt could never re-find the (now
+ * non-CREDIT/DEPOSIT) inflow activity — leaving the pair permanently
+ * half-reclassified. One request, one failure path avoids that split-write
+ * state.
+ *
+ * `saveMany` can also resolve successfully while still reporting a per-item
+ * failure in `result.errors` rather than throwing — that's checked here and
+ * turned into a thrown error so the caller's existing catch/retry path (in
+ * `runReconciliation`) treats it the same as a hard failure, instead of
+ * counting the candidate resolved while one or both legs never actually
+ * changed.
+ */
+async function reclassifyPair(
+  api: HostAPI,
+  inflowRow: ActivityDetails,
+  withdrawalRow: ActivityDetails,
+  sfTransactionId: string,
+): Promise<void> {
+  const result = await api.activities.saveMany({
+    creates: [
+      toCreate(inflowRow, 'TRANSFER_IN', sfTransactionId),
+      toCreate(withdrawalRow, 'TRANSFER_OUT', sfTransactionId),
+    ],
+    deleteIds: [inflowRow.id, withdrawalRow.id],
+  });
+  if (result.errors.length > 0) {
+    throw new Error(
+      `saveMany reported per-item errors for candidate ${sfTransactionId}: ${JSON.stringify(result.errors)}`,
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Run the full suite and type-check**
+
+Run: `pnpm test && pnpm type-check`
+Expected: PASS — all tests pass, including the 4 updated in Step 1; no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/sync/reconciliation.ts src/lib/sync/reconciliation.test.ts
+git commit -m "fix: link reclassified transfer legs via sourceGroupId instead of update()"
+```
+
+---
+
+### Task 3: Manual verification against the live e2e host
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build and package**
+
+Run: `pnpm bundle`
+Expected: `dist/simplefin-wealthfolio-addon-1.0.0.zip` produced with no build errors.
+
+- [ ] **Step 2: Install into the `wealthfolio-e2e` container**
+
+Reuse the flow from this investigation: on `http://localhost:8088/settings/addons`, click the "+" button → "Install from File" → upload `dist/simplefin-wealthfolio-addon-1.0.0.zip` → "Approve & Install". This replaces the currently-installed build; existing config/mappings persist (same addon id).
+
+Note: interacting with the addon's own sandboxed iframe content (its tabs, "Sync now" button) was unreachable via this session's browser-automation tooling — clicks and keyboard input did not register anywhere inside it, across repeated attempts. The Addon Manager page itself (outside the iframe) was unaffected. If this is still the case, trigger "Sync now" from inside the actual Wealthfolio window directly (mouse/keyboard on the real display) rather than through automation, or ask the user to click it.
+
+- [ ] **Step 3: Run a sync and confirm a transfer gets linked**
+
+Trigger "Sync now" on a mapping that has at least one pending card-payment or cash-transfer candidate ready to resolve (check the "Staged" tab first). After it resolves, check `http://localhost:8088/health` (or wherever the Data Consistency checker surfaces) and confirm the newly-reclassified pair is no longer flagged as an incomplete transfer.
+
+Expected: the reclassified pair does not appear in the incomplete-transfers list. (The 28 pairs already flagged before this fix existed were reclassified under the old `update()` path and remain unlinked — this step is about confirming *new* reclassifications are linked, not retroactively fixing the existing 28.)
+
+- [ ] **Step 4: No commit** — this task is verification only, nothing to commit.

--- a/docs/superpowers/specs/2026-08-14-reclassify-credit-card-payments-design.md
+++ b/docs/superpowers/specs/2026-08-14-reclassify-credit-card-payments-design.md
@@ -40,6 +40,9 @@ shape the design below:
   update payload but came back `null` in the response and in every later
   read. The "visually link the pair via `sourceGroupId`" nice-to-have from
   the original issue does not work and is dropped from this design.
+  (Follow-up: this was true for `update()` specifically —
+  `docs/superpowers/specs/2026-08-26-sourcegroupid-transfer-linking-design.md`
+  later found the create path does persist it.)
 - **`import()`'s response is not a source of real activity ids.** It echoes
   back the submitted `ActivityImport` objects (including their synthetic
   preview ids), not the persisted `Activity` records. Real ids must come

--- a/docs/superpowers/specs/2026-08-26-backfill-relink-unlinked-transfers-design.md
+++ b/docs/superpowers/specs/2026-08-26-backfill-relink-unlinked-transfers-design.md
@@ -1,0 +1,198 @@
+# Backfill-Relink Pre-Existing Unlinked Transfer Pairs — Design
+
+Implements [#71](https://github.com/christancho/simplefin-wealthfolio-addon/issues/71).
+
+## Problem
+
+#69 / PR #70 fixed `reclassifyPair()` (`src/lib/sync/reconciliation.ts`) so
+newly-reconciled transfers get linked via `sourceGroupId`, stopping
+Wealthfolio's Data Consistency checker from flagging them as incomplete
+transfers going forward. It does nothing for transfers already reclassified
+to `TRANSFER_IN`/`TRANSFER_OUT` by the old `update()`-based code before that
+fix landed — 28 in production as of 2026-08-26, confirmed still flagged
+after installing the fix and running a fresh sync.
+
+Two independent reasons the existing pipeline never revisits them:
+
+1. Reclassification is one-shot — once `reclassifyPair()` resolves a
+   candidate, `runReconciliation` drops it from `remaining` and it's never
+   processed again.
+2. The backfill scanner (`findBackfillCandidatesOfType`,
+   `reconciliation.ts:140`) only searches `CREDIT`/`DEPOSIT` activities —
+   activities already typed `TRANSFER_IN`/`TRANSFER_OUT` never match that
+   search, so they're invisible to it.
+
+## Design
+
+### New matching function, reusing existing pieces
+
+`withdrawalMatches` (`reconciliation.ts:93`) already does exactly the
+matching this needs — same amount, opposite account, within
+`MATCH_WINDOW_DAYS` — but its signature takes a `StagedCandidate`. Generalize
+it to take a narrower shape instead, so both the existing candidate-matching
+path and the new backfill-relink path can share it:
+
+```ts
+type MatchTarget = Pick<StagedCandidate, 'inflowAccountId' | 'amount' | 'postedDate'>;
+
+function withdrawalMatches(withdrawals: ActivityDetails[], target: MatchTarget): ActivityDetails[] {
+  // body unchanged except `candidate.` -> `target.`
+}
+```
+
+A `StagedCandidate` already structurally satisfies `MatchTarget`, so every
+existing call site (`runReconciliation`) needs no change beyond the
+parameter type.
+
+### Reading `sourceGroupId` off search results
+
+`ActivityDetails` (returned by `activities.search()`) doesn't declare
+`sourceGroupId` in the SDK's shipped types — only `Activity` (the shape
+`create`/`update`/`saveMany` return) does. The 2026-08-26 live probe already
+established the field is present in the runtime JSON regardless (it read it
+off a fresh `search()` call successfully via a cast). Add the same cast as a
+small named helper so every read site is consistent:
+
+```ts
+/**
+ * `sourceGroupId` is on the host's `Activity` model but missing from the
+ * SDK's `ActivityDetails` type — confirmed present in the runtime JSON
+ * regardless (2026-08-26 live probe). This cast is the one place that gap
+ * is bridged; every other read goes through this function.
+ */
+function sourceGroupIdOf(row: ActivityDetails): string | null {
+  return ((row as unknown as Record<string, unknown>).sourceGroupId as string | null | undefined) ?? null;
+}
+```
+
+### `relinkUnlinkedTransferPairs`
+
+```ts
+export interface RelinkSummary {
+  relinked: number;
+  ambiguous: number;
+}
+
+export async function relinkUnlinkedTransferPairs(
+  api: HostAPI,
+  inflowAccountIds: string[],
+  cashAccountIds: string[],
+): Promise<RelinkSummary> {
+  if (inflowAccountIds.length === 0 || cashAccountIds.length === 0) {
+    return { relinked: 0, ambiguous: 0 };
+  }
+
+  const [transferIns, transferOuts] = await Promise.all([
+    searchAllByType(api, inflowAccountIds, 'TRANSFER_IN'),
+    searchAllByType(api, cashAccountIds, 'TRANSFER_OUT'),
+  ]);
+  const unlinkedIns = transferIns.filter((r) => !sourceGroupIdOf(r));
+  const unlinkedOuts = transferOuts.filter((r) => !sourceGroupIdOf(r));
+
+  let relinked = 0;
+  let ambiguous = 0;
+  const claimedOutIds = new Set<string>();
+
+  for (const inRow of unlinkedIns) {
+    const target: MatchTarget = {
+      inflowAccountId: inRow.accountId,
+      amount: inRow.amount ?? '0',
+      postedDate: toIsoDateOnly(inRow.date),
+    };
+    const matches = withdrawalMatches(unlinkedOuts, target).filter((o) => !claimedOutIds.has(o.id));
+
+    if (matches.length === 0) continue;
+    if (matches.length > 1) {
+      ambiguous += 1;
+      continue;
+    }
+
+    try {
+      await reclassifyPair(api, inRow, matches[0], inRow.id);
+      claimedOutIds.add(matches[0].id);
+      relinked += 1;
+    } catch (error) {
+      api.logger.error(`[simplefin] relink failed for TRANSFER_IN ${inRow.id}: ${String(error)}`);
+    }
+  }
+
+  return { relinked, ambiguous };
+}
+```
+
+`inflowAccountIds` is the union of card and cash account ids (`TRANSFER_IN`
+can land on either, mirroring how `CREDIT`/`DEPOSIT` did before
+reclassification); `cashAccountIds` alone for `TRANSFER_OUT`, since money
+only ever leaves a cash account — identical to how `withdrawalMatches`'
+existing account-exclusion logic already treats `WITHDRAWAL`.
+
+`reclassifyPair(api, inRow, matches[0], inRow.id)` is called directly, unchanged
+— it already deletes both rows and recreates them typed `TRANSFER_IN`/
+`TRANSFER_OUT` with `sourceGroupId` set (using `inRow.id` as the grouping key,
+the same "reuse the deleted row's own id" precedent
+`findBackfillCandidatesOfType` already established for backfilled
+candidates — see the comment at `reconciliation.ts:155`). The two rows keep
+the same activity type they already had; only the link and the previously-
+dropped `fee`/`subtype` fields change.
+
+**Deliberately no ambiguous-match UI.** Every existing `TRANSFER_IN`/
+`TRANSFER_OUT` pair was created by a *past* unambiguous match — that's the
+only way `reclassifyPair` was ever called. Re-deriving that same match now
+should essentially never produce ambiguity unless a new, coincidentally
+same-amount transaction has appeared since. Building staged-candidate/UI
+plumbing for that rare case isn't worth the complexity; `ambiguous` is
+counted and surfaced in the scan result text so it isn't silent, but the
+pair is simply left alone (still unlinked, still flagged by Wealthfolio,
+exactly as it was before running the scan).
+
+Note this population is not limited to pairs this addon itself created:
+`relinkUnlinkedTransferPairs` matches *any* unlinked `TRANSFER_IN`/
+`TRANSFER_OUT` pair in the mapped accounts, regardless of what created it —
+a manual entry, a CSV import, or another addon are just as eligible as this
+addon's own past reclassifications, since Wealthfolio's Data Consistency
+checker doesn't distinguish by provenance either, only by whether the link
+exists.
+
+### Trigger: fold into the existing "Scan" button
+
+`StagedTransactionsList.tsx`'s `scanForOlderPayments` already exists as the
+opt-in, manual action for "catch up on anything the live pipeline missed" —
+the button was already renamed once (see commit `f66643c`) to reflect
+scope growing beyond payments into transfers. This is the same story again:
+add a call to `relinkUnlinkedTransferPairs` alongside the existing
+`findBackfillCandidates`/`runReconciliation` calls, in the same handler, and
+extend the button/result text to mention it.
+
+This is a deliberate choice, not just convenience: per the risk note in
+issue #71, delete+recreate on activities that can be arbitrarily older than
+the ~7-day live-candidate window carries more risk of losing something
+keyed to the old activity id (e.g. manual categorization) than the original
+fix's few-day window ever did. Keeping it behind the same explicit,
+user-initiated action — never automatic on every sync — is the mitigation;
+nothing here changes `runSync`.
+
+**Result visibility.** Per the project's rule against fire-and-forget
+operations, the scan's outcome must be visible, not just logged. Add a
+result-summary state that renders under the button after a scan completes,
+covering both the existing backfill count and the new relink/ambiguous
+counts (e.g. "Found 2 new candidates. Relinked 5 pairs, 0 ambiguous.") —
+shown even when all counts are zero, so a no-op scan isn't silent either.
+
+## Testing
+
+- `reconciliation.test.ts`: new tests for `relinkUnlinkedTransferPairs`
+  covering — unambiguous relink calls `saveMany` with the expected
+  `creates`/`deleteIds` shape and `sourceGroupId: <transferIn.id>`; a row
+  with `sourceGroupId` already set is excluded from matching entirely; zero
+  matches is a no-op; 2+ matches increments `ambiguous` and calls `saveMany`
+  zero times for that row; a `reclassifyPair` failure for one row doesn't
+  block a later row in the same run (mirrors the existing per-candidate
+  isolation test in `runReconciliation`); empty `inflowAccountIds` or
+  `cashAccountIds` returns `{ relinked: 0, ambiguous: 0 }` without calling
+  `search`.
+- `withdrawalMatches`'s existing test coverage (indirectly, via
+  `runReconciliation`'s tests) continues to exercise it unchanged after the
+  `StagedCandidate` → `MatchTarget` signature generalization — no behavior
+  change, so no new tests needed for that piece alone.
+- `StagedTransactionsList.test.tsx`: extend the existing scan-button test(s)
+  to cover the new relink call and the result-summary text.

--- a/docs/superpowers/specs/2026-08-26-sourcegroupid-transfer-linking-design.md
+++ b/docs/superpowers/specs/2026-08-26-sourcegroupid-transfer-linking-design.md
@@ -1,0 +1,163 @@
+# Link Reclassified Transfers via sourceGroupId — Design
+
+Implements [#69](https://github.com/christancho/simplefin-wealthfolio-addon/issues/69).
+
+## Problem
+
+Wealthfolio's built-in "Data Consistency" checker flags every transfer this
+addon reclassifies as an "incomplete transfer" — 28 flagged in production as
+of 2026-08-26 — even when both legs are correctly typed `TRANSFER_IN`/
+`TRANSFER_OUT` and match exactly on amount/date/account. The checker appears
+to require an explicit link between the two legs rather than matching on
+type+amount+date heuristically: a same-day, same-amount $3000 CAD pair was
+still shown as unpaired.
+
+`reclassifyPair()` (`src/lib/sync/reconciliation.ts:218`) reclassifies both
+legs via `activities.saveMany({ updates: [...] })` and deliberately never
+sets `sourceGroupId`, per a 2026-08-14 finding
+(`docs/superpowers/specs/2026-08-14-reclassify-credit-card-payments-design.md:39`)
+that `activities.update()` silently drops that field.
+
+## Verified against a live host (2026-08-26)
+
+That 2026-08-14 finding only tested `activities.update()`. A fresh probe —
+built as a temporary auto-running tab on the Sync page, removed before this
+plan — ran against a live `wealthfolio-e2e` container (host v3.6.3) and
+tested every mutation path this addon has permission to call:
+
+- **`saveMany({ creates: [...] })` with `sourceGroupId` set persists it.**
+  Both the mutation's own response and a fresh, independent `search()` call
+  afterward showed the value.
+- **`activities.update()` with `sourceGroupId` set does not.** Re-confirms
+  the 2026-08-14 finding: the field in both the response and the later
+  `search()` read stayed at whatever it was before the update, ignoring the
+  new value entirely.
+- **Raw `activities.create()` was not tested** — this addon's manifest only
+  declares `checkImport`, `import`, `search`, `update`, `saveMany` for the
+  `activities` category, and a live call confirmed the host rejects
+  `create()` outright ("Addon 'simplefin-sync' is not allowed to call
+  activities.create"). Not needed anyway: `saveMany({ creates })` already
+  covers the create path and needs no manifest change, confirmed by the
+  probe running under the existing permission set.
+- **`saveMany({ deleteIds: [...] })` also needs no extra permission** — the
+  probe's cleanup step deleted its own test activities this way without any
+  permission error, and a follow-up search confirmed they were gone.
+
+**Conclusion:** linking the pair is possible. It requires creating new
+`TRANSFER_IN`/`TRANSFER_OUT` activities with `sourceGroupId` set, not
+updating the existing `CREDIT`/`DEPOSIT`/`WITHDRAWAL` activities in place.
+
+## Design
+
+### `reclassifyPair()` switches from update to delete+recreate
+
+Currently:
+
+```ts
+async function reclassifyPair(api, inflowRow, withdrawalRow, sfTransactionId) {
+  const result = await api.activities.saveMany({
+    updates: [toUpdate(inflowRow, 'TRANSFER_IN'), toUpdate(withdrawalRow, 'TRANSFER_OUT')],
+  });
+  ...
+}
+```
+
+Becomes:
+
+```ts
+function toCreate(row: ActivityDetails, activityType: string, sourceGroupId: string): ActivityCreate {
+  return {
+    accountId: row.accountId,
+    activityType,
+    activityDate: row.date,
+    amount: row.amount,
+    currency: row.currency,
+    comment: row.comment,
+    sourceGroupId,
+  };
+}
+
+async function reclassifyPair(api, inflowRow, withdrawalRow, sfTransactionId) {
+  const result = await api.activities.saveMany({
+    creates: [
+      toCreate(inflowRow, 'TRANSFER_IN', sfTransactionId),
+      toCreate(withdrawalRow, 'TRANSFER_OUT', sfTransactionId),
+    ],
+    deleteIds: [inflowRow.id, withdrawalRow.id],
+  });
+  if (result.errors.length > 0) {
+    throw new Error(`saveMany reported per-item errors for candidate ${sfTransactionId}: ${JSON.stringify(result.errors)}`);
+  }
+}
+```
+
+Both legs are still linked and deleted in a single `saveMany` call, for the
+same reason the existing code already does one call instead of two: if the
+host applied one leg and then failed the other, a split write would leave
+the pair half-reclassified with no way to recover it on the next run (the
+existing comment on this function explains why — that reasoning doesn't
+change, only the payload shape does).
+
+### `sourceGroupId` value: the candidate's `sfTransactionId`
+
+No new id generation is needed. `StagedCandidate.sfTransactionId` (the
+SimpleFIN transaction id of the inflow leg) is already unique per
+reconciled pair and stable for the lifetime of the candidate — it's the
+natural grouping key and avoids pulling in a UUID dependency for something
+that already has one.
+
+### `resolveAmbiguous()` needs no change
+
+It already delegates to `reclassifyPair()` for the actual reclassification,
+so the delete+recreate happens automatically once that function changes.
+
+### New activity ids
+
+Reclassification always happens as the terminal step for a candidate — once
+`reclassifyPair()` succeeds, the candidate is dropped from staging (never
+pushed back into `remaining` in `runReconciliation`, per the existing
+control flow) and its old `inflowActivityId`/withdrawal id are never looked
+up again. The new ids `saveMany` returns are not needed by anything
+downstream and are not captured.
+
+### Accepted risk: delete+recreate loses anything keyed to the old activity id
+
+Deleting the original `CREDIT`/`DEPOSIT`/`WITHDRAWAL` activity and creating
+a new `TRANSFER_IN`/`TRANSFER_OUT` one means anything Wealthfolio keeps
+keyed to the old activity id — a manual category assignment, for example —
+does not carry over. In practice this window is small: reconciliation runs
+on every sync and a candidate expires after `EXPIRY_DAYS` (7 days) if never
+matched, so a reclassified activity has usually existed for at most a few
+days before this happens. This is accepted as-is; not solved by this plan.
+
+## Testing
+
+`src/test/mockHost.ts`'s default `saveMany` mock only echoes back
+`updates`. It needs to also echo `creates` into `created` (assigning each a
+synthetic id, the same way `checkImport`/`import` already do for other
+flows) and to report `deleteIds` in `deleted`, since the reconciliation
+tests assert on `saveMany`'s exact call shape and some assert on `created`
+ids implicitly via `resolveAmbiguous`/`runReconciliation`'s return values.
+
+Existing assertions of the form:
+
+```ts
+expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+  updates: [
+    expect.objectContaining({ id: 'CARD-ACT-1', activityType: 'TRANSFER_IN' }),
+    expect.objectContaining({ id: 'CASH-ACT-1', activityType: 'TRANSFER_OUT' }),
+  ],
+});
+```
+
+become:
+
+```ts
+expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+  creates: [
+    expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-1' }),
+    expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-1' }),
+  ],
+  deleteIds: ['CARD-ACT-1', 'CASH-ACT-1'],
+});
+```

--- a/manifest.json
+++ b/manifest.json
@@ -66,7 +66,6 @@
         { "name": "checkImport", "isDeclared": true, "isDetected": false },
         { "name": "import", "isDeclared": true, "isDetected": false },
         { "name": "search", "isDeclared": true, "isDetected": false },
-        { "name": "update", "isDeclared": true, "isDetected": false },
         { "name": "saveMany", "isDeclared": true, "isDetected": false }
       ],
       "purpose": "Import cash transactions fetched from SimpleFIN, and reconcile credit-card payments and cash-to-cash transfers into linked transfers."

--- a/src/components/StagedTransactionsList.test.tsx
+++ b/src/components/StagedTransactionsList.test.tsx
@@ -227,7 +227,7 @@ describe('StagedTransactionsList', () => {
     render(<StagedTransactionsList api={host.api} {...defaultProps} />);
     await screen.findByText(/no staged transactions/i);
 
-    await userEvent.click(screen.getByRole('button', { name: /scan for older payments/i }));
+    await userEvent.click(screen.getByRole('button', { name: /scan for older/i }));
 
     expect(await screen.findByText('$75.00')).toBeInTheDocument();
     expect(screen.getByText('pending')).toBeInTheDocument();
@@ -272,7 +272,7 @@ describe('StagedTransactionsList', () => {
     render(<StagedTransactionsList api={host.api} {...defaultProps} />);
     await screen.findByText(/no staged transactions/i);
 
-    await userEvent.click(screen.getByRole('button', { name: /scan for older payments/i }));
+    await userEvent.click(screen.getByRole('button', { name: /scan for older/i }));
 
     expect(await screen.findByText(/no staged transactions/i)).toBeInTheDocument();
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
@@ -325,7 +325,7 @@ describe('StagedTransactionsList', () => {
     render(<StagedTransactionsList api={host.api} {...defaultProps} />);
     await screen.findByText(/no staged transactions/i);
 
-    await userEvent.click(screen.getByRole('button', { name: /scan for older payments/i }));
+    await userEvent.click(screen.getByRole('button', { name: /scan for older/i }));
 
     expect(await screen.findByText(/relinked 1 transfer pair/i)).toBeInTheDocument();
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({

--- a/src/components/StagedTransactionsList.test.tsx
+++ b/src/components/StagedTransactionsList.test.tsx
@@ -193,10 +193,11 @@ describe('StagedTransactionsList', () => {
     await userEvent.click(within(dialog).getByRole('button', { name: /confirm/i }));
 
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
-      updates: [
-        expect.objectContaining({ id: 'CARD-ACT-2', activityType: 'TRANSFER_IN' }),
-        expect.objectContaining({ id: 'CASH-A', activityType: 'TRANSFER_OUT' }),
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-2' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-2' }),
       ],
+      deleteIds: ['CARD-ACT-2', 'CASH-A'],
     });
     expect(await screen.findByText(/no staged transactions/i)).toBeInTheDocument();
   });
@@ -275,10 +276,11 @@ describe('StagedTransactionsList', () => {
 
     expect(await screen.findByText(/no staged transactions/i)).toBeInTheDocument();
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
-      updates: [
-        expect.objectContaining({ id: 'OLD-CARD-ACT', activityType: 'TRANSFER_IN' }),
-        expect.objectContaining({ id: 'OLD-CASH-ACT', activityType: 'TRANSFER_OUT' }),
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'OLD-CARD-ACT' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'OLD-CARD-ACT' }),
       ],
+      deleteIds: ['OLD-CARD-ACT', 'OLD-CASH-ACT'],
     });
   });
 });

--- a/src/components/StagedTransactionsList.test.tsx
+++ b/src/components/StagedTransactionsList.test.tsx
@@ -283,4 +283,57 @@ describe('StagedTransactionsList', () => {
       deleteIds: ['OLD-CARD-ACT', 'OLD-CASH-ACT'],
     });
   });
+
+  it('relinks unlinked transfer pairs found during a scan and reports the count', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') {
+        return {
+          data: [
+            {
+              id: 'OLD-TIN-1',
+              accountId: 'WF-CARD',
+              activityType: 'TRANSFER_IN',
+              date: '2025-08-06T00:00:00+00:00',
+              amount: '50',
+              currency: 'USD',
+              comment: 'Old payment',
+            },
+          ],
+          meta: { totalRowCount: 1 },
+        };
+      }
+      if (filters.activityTypes === 'TRANSFER_OUT') {
+        return {
+          data: [
+            {
+              id: 'OLD-TOUT-1',
+              accountId: 'WF-CASH',
+              activityType: 'TRANSFER_OUT',
+              date: '2025-08-05T00:00:00+00:00',
+              amount: '50',
+              currency: 'USD',
+              comment: 'Old withdrawal',
+            },
+          ],
+          meta: { totalRowCount: 1 },
+        };
+      }
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    render(<StagedTransactionsList api={host.api} {...defaultProps} />);
+    await screen.findByText(/no staged transactions/i);
+
+    await userEvent.click(screen.getByRole('button', { name: /scan for older payments/i }));
+
+    expect(await screen.findByText(/relinked 1 pair/i)).toBeInTheDocument();
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'OLD-TIN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'OLD-TIN-1' }),
+      ],
+      deleteIds: ['OLD-TIN-1', 'OLD-TOUT-1'],
+    });
+  });
 });

--- a/src/components/StagedTransactionsList.test.tsx
+++ b/src/components/StagedTransactionsList.test.tsx
@@ -327,7 +327,7 @@ describe('StagedTransactionsList', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /scan for older payments/i }));
 
-    expect(await screen.findByText(/relinked 1 pair/i)).toBeInTheDocument();
+    expect(await screen.findByText(/relinked 1 transfer pair/i)).toBeInTheDocument();
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
       creates: [
         expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'OLD-TIN-1' }),

--- a/src/components/StagedTransactionsList.tsx
+++ b/src/components/StagedTransactionsList.tsx
@@ -124,9 +124,9 @@ export function StagedTransactionsList({
       setCandidates(remaining);
       await writeStaging(api, remaining);
 
-      const { relinked, ambiguous } = await relinkUnlinkedTransferPairs(api, [...cardAccountIds, ...cashAccountIds], cashAccountIds);
+      const { relinked, unmatched, ambiguous, failed } = await relinkUnlinkedTransferPairs(api, [...cardAccountIds, ...cashAccountIds], cashAccountIds);
       setScanResult(
-        `Found ${found.length} new candidate${found.length === 1 ? '' : 's'}. Relinked ${relinked} pair${relinked === 1 ? '' : 's'}, ${ambiguous} ambiguous.`,
+        `Found ${found.length} new candidate${found.length === 1 ? '' : 's'}. Relinked ${relinked} transfer pair${relinked === 1 ? '' : 's'}: ${unmatched} had no match, ${ambiguous} had multiple candidates, ${failed} failed.`,
       );
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));

--- a/src/components/StagedTransactionsList.tsx
+++ b/src/components/StagedTransactionsList.tsx
@@ -136,8 +136,8 @@ export function StagedTransactionsList({
   }
 
   const scanButton = (
-    <div className="flex flex-col gap-1">
-      <Button size="sm" variant="outline" onClick={scanForOlderPayments} disabled={scanning}>
+    <div className="flex flex-col items-start gap-1">
+      <Button size="sm" variant="outline" className="h-auto max-w-md whitespace-normal text-left" onClick={scanForOlderPayments} disabled={scanning}>
         {scanning ? 'Scanning…' : 'Scan for older credit card payments, bank transfers and unlinked transfer pairs'}
       </Button>
       {scanResult && <p className="text-muted-foreground text-sm">{scanResult}</p>}

--- a/src/components/StagedTransactionsList.tsx
+++ b/src/components/StagedTransactionsList.tsx
@@ -137,7 +137,7 @@ export function StagedTransactionsList({
 
   const scanButton = (
     <div className="flex flex-col items-start gap-1">
-      <Button size="sm" variant="outline" className="h-auto max-w-md whitespace-normal text-left" onClick={scanForOlderPayments} disabled={scanning}>
+      <Button size="sm" className="h-auto max-w-md whitespace-normal text-left" onClick={scanForOlderPayments} disabled={scanning}>
         {scanning ? 'Scanning…' : 'Scan for older credit card payments, bank transfers and unlinked transfer pairs'}
       </Button>
       {scanResult && <p className="text-muted-foreground text-sm">{scanResult}</p>}

--- a/src/components/StagedTransactionsList.tsx
+++ b/src/components/StagedTransactionsList.tsx
@@ -15,7 +15,7 @@ import {
   formatAmount,
 } from '@wealthfolio/ui';
 import { Fragment, useEffect, useState } from 'react';
-import { describeWithdrawals, findBackfillCandidates, resolveAmbiguous, runReconciliation } from '../lib/sync/reconciliation';
+import { describeWithdrawals, findBackfillCandidates, relinkUnlinkedTransferPairs, resolveAmbiguous, runReconciliation } from '../lib/sync/reconciliation';
 import { readStaging, writeStaging, type StagedCandidate } from '../lib/storage/staging';
 import { compactCellClassName, compactHeadClassName } from './tableStyle';
 
@@ -59,6 +59,7 @@ export function StagedTransactionsList({
   const [chosenId, setChosenId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [scanning, setScanning] = useState(false);
+  const [scanResult, setScanResult] = useState<string | null>(null);
 
   async function load() {
     try {
@@ -109,6 +110,7 @@ export function StagedTransactionsList({
 
   async function scanForOlderPayments() {
     setError(null);
+    setScanResult(null);
     setScanning(true);
     try {
       const existing = await readStaging(api);
@@ -121,6 +123,11 @@ export function StagedTransactionsList({
       );
       setCandidates(remaining);
       await writeStaging(api, remaining);
+
+      const { relinked, ambiguous } = await relinkUnlinkedTransferPairs(api, [...cardAccountIds, ...cashAccountIds], cashAccountIds);
+      setScanResult(
+        `Found ${found.length} new candidate${found.length === 1 ? '' : 's'}. Relinked ${relinked} pair${relinked === 1 ? '' : 's'}, ${ambiguous} ambiguous.`,
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -129,9 +136,12 @@ export function StagedTransactionsList({
   }
 
   const scanButton = (
-    <Button size="sm" variant="outline" onClick={scanForOlderPayments} disabled={scanning}>
-      {scanning ? 'Scanning…' : 'Scan for older payments and transfers'}
-    </Button>
+    <div className="flex flex-col gap-1">
+      <Button size="sm" variant="outline" onClick={scanForOlderPayments} disabled={scanning}>
+        {scanning ? 'Scanning…' : 'Scan for older payments, transfers, and unlinked pairs'}
+      </Button>
+      {scanResult && <p className="text-muted-foreground text-sm">{scanResult}</p>}
+    </div>
   );
 
   if (candidates === null) {

--- a/src/components/StagedTransactionsList.tsx
+++ b/src/components/StagedTransactionsList.tsx
@@ -138,7 +138,7 @@ export function StagedTransactionsList({
   const scanButton = (
     <div className="flex flex-col gap-1">
       <Button size="sm" variant="outline" onClick={scanForOlderPayments} disabled={scanning}>
-        {scanning ? 'Scanning…' : 'Scan for older payments, transfers, and unlinked pairs'}
+        {scanning ? 'Scanning…' : 'Scan for older credit card payments, bank transfers and unlinked transfer pairs'}
       </Button>
       {scanResult && <p className="text-muted-foreground text-sm">{scanResult}</p>}
     </div>

--- a/src/lib/sync/openingBalance.test.ts
+++ b/src/lib/sync/openingBalance.test.ts
@@ -38,30 +38,53 @@ describe('buildOpeningBalanceActivity', () => {
       { sfBalance: '100.00', wfBalance: '100.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
       mapping,
       'USD',
+      'CASH',
     );
     expect(activity).toBeNull();
   });
 
-  it('builds a TRANSFER_IN when Wealthfolio is short of the SimpleFIN balance', () => {
+  it('builds a DEPOSIT when Wealthfolio is short of the SimpleFIN balance', () => {
     const activity = buildOpeningBalanceActivity(
       { sfBalance: '100.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
       mapping,
       'USD',
+      'CASH',
     );
-    expect(activity?.activityType).toBe('TRANSFER_IN');
+    expect(activity?.activityType).toBe('DEPOSIT');
     expect(activity?.amount).toBe('20.00');
     expect(activity?.accountId).toBe('WF-1');
     expect(activity?.currency).toBe('USD');
   });
 
-  it('builds a TRANSFER_OUT when Wealthfolio holds more than the SimpleFIN balance', () => {
+  it('builds a WITHDRAWAL when Wealthfolio holds more than the SimpleFIN balance', () => {
     const activity = buildOpeningBalanceActivity(
       { sfBalance: '50.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
       mapping,
       'USD',
+      'CASH',
     );
-    expect(activity?.activityType).toBe('TRANSFER_OUT');
+    expect(activity?.activityType).toBe('WITHDRAWAL');
     expect(activity?.amount).toBe('30.00');
+  });
+
+  it('builds a CREDIT instead of a DEPOSIT on a credit-card account', () => {
+    const activity = buildOpeningBalanceActivity(
+      { sfBalance: '100.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
+      mapping,
+      'USD',
+      'CREDIT_CARD',
+    );
+    expect(activity?.activityType).toBe('CREDIT');
+  });
+
+  it('still builds a WITHDRAWAL (not CREDIT) on a credit-card account when Wealthfolio holds more', () => {
+    const activity = buildOpeningBalanceActivity(
+      { sfBalance: '50.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
+      mapping,
+      'USD',
+      'CREDIT_CARD',
+    );
+    expect(activity?.activityType).toBe('WITHDRAWAL');
   });
 
   it('dates the entry one day before the earliest posted transaction', () => {
@@ -69,6 +92,7 @@ describe('buildOpeningBalanceActivity', () => {
       { sfBalance: '100.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
       mapping,
       'USD',
+      'CASH',
     );
     // earliestPosted 1754438400 -> 2025-08-06; one day before -> 2025-08-05
     expect(activity?.date).toBe('2025-08-05');
@@ -79,6 +103,7 @@ describe('buildOpeningBalanceActivity', () => {
       { sfBalance: '100.00', wfBalance: '0', earliestPosted: null, balanceDate: 1754524800 },
       mapping,
       'USD',
+      'CASH',
     );
     expect(activity?.date).toBe('2025-08-07');
   });
@@ -88,6 +113,7 @@ describe('buildOpeningBalanceActivity', () => {
       { sfBalance: '100.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
       mapping,
       'USD',
+      'CASH',
     );
     expect(activity?.symbol).toBe('');
   });

--- a/src/lib/sync/openingBalance.ts
+++ b/src/lib/sync/openingBalance.ts
@@ -1,4 +1,4 @@
-import type { ActivityImport } from '@wealthfolio/addon-sdk';
+import type { AccountType, ActivityImport } from '@wealthfolio/addon-sdk';
 import type { AccountMapping } from '../storage/config';
 
 const SECONDS_PER_DAY = 86_400;
@@ -65,11 +65,20 @@ function isoDate(epochSeconds: number): string {
  * One-time synthetic activity that plugs the gap between SimpleFIN's current
  * balance and whatever landed in Wealthfolio from the full-history backfill —
  * returns null when there is no gap.
+ *
+ * Imported as `DEPOSIT`/`WITHDRAWAL` (or `CREDIT` in place of `DEPOSIT` on a
+ * credit-card account, mirroring `toActivityImport`), never `TRANSFER_IN`/
+ * `TRANSFER_OUT` — this plug has no counterparty leg by construction (it's
+ * money the account already had before this addon started tracking it, not a
+ * transfer between two tracked accounts), so typing it as a transfer would
+ * leave it permanently unlinkable and always flagged by Wealthfolio's Data
+ * Consistency checker.
  */
 export function buildOpeningBalanceActivity(
   input: OpeningBalanceInput,
   mapping: AccountMapping,
   currency: string,
+  destinationAccountType: AccountType,
 ): ActivityImport | null {
   const remainder = subtractDecimal(input.sfBalance, input.wfBalance);
   if (/^0(\.0*)?$/.test(remainder)) return null;
@@ -78,10 +87,11 @@ export function buildOpeningBalanceActivity(
   const magnitude = remainder.replace(/^-/, '');
   const dateEpoch =
     input.earliestPosted !== null ? input.earliestPosted - SECONDS_PER_DAY : input.balanceDate;
+  const inflowType = destinationAccountType === 'CREDIT_CARD' ? 'CREDIT' : 'DEPOSIT';
 
   return {
     accountId: mapping.wfAccountId,
-    activityType: isOutflow ? 'TRANSFER_OUT' : 'TRANSFER_IN',
+    activityType: isOutflow ? 'WITHDRAWAL' : inflowType,
     date: isoDate(dateEpoch),
     amount: magnitude,
     currency,

--- a/src/lib/sync/reconciliation.test.ts
+++ b/src/lib/sync/reconciliation.test.ts
@@ -64,10 +64,11 @@ describe('runReconciliation', () => {
     expect(candidates).toHaveLength(0);
     expect(summary.resolved).toBe(1);
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
-      updates: [
-        expect.objectContaining({ id: 'CARD-ACT-1', activityType: 'TRANSFER_IN' }),
-        expect.objectContaining({ id: 'CASH-ACT-1', activityType: 'TRANSFER_OUT' }),
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-1' }),
       ],
+      deleteIds: ['CARD-ACT-1', 'CASH-ACT-1'],
     });
   });
 
@@ -102,10 +103,11 @@ describe('runReconciliation', () => {
     expect(candidates).toHaveLength(0);
     expect(summary.resolved).toBe(1);
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
-      updates: [
-        expect.objectContaining({ id: 'DEPOSIT-ACT-1', activityType: 'TRANSFER_IN' }),
-        expect.objectContaining({ id: 'CASH-ACT-1', activityType: 'TRANSFER_OUT' }),
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CASH-B', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH-A', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-1' }),
       ],
+      deleteIds: ['DEPOSIT-ACT-1', 'CASH-ACT-1'],
     });
   });
 
@@ -630,10 +632,11 @@ describe('resolveAmbiguous', () => {
     );
 
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
-      updates: [
-        expect.objectContaining({ id: 'CARD-ACT-1', activityType: 'TRANSFER_IN' }),
-        expect.objectContaining({ id: 'CASH-ACT-1', activityType: 'TRANSFER_OUT' }),
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-1' }),
       ],
+      deleteIds: ['CARD-ACT-1', 'CASH-ACT-1'],
     });
   });
 
@@ -664,10 +667,11 @@ describe('resolveAmbiguous', () => {
     );
 
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
-      updates: [
-        expect.objectContaining({ id: 'DEPOSIT-ACT-1', activityType: 'TRANSFER_IN' }),
-        expect.objectContaining({ id: 'CASH-ACT-1', activityType: 'TRANSFER_OUT' }),
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CASH-B', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-1' }),
       ],
+      deleteIds: ['DEPOSIT-ACT-1', 'CASH-ACT-1'],
     });
   });
 

--- a/src/lib/sync/reconciliation.test.ts
+++ b/src/lib/sync/reconciliation.test.ts
@@ -6,6 +6,7 @@ import {
   describeWithdrawals,
   findBackfillCandidates,
   findInflowActivity,
+  relinkUnlinkedTransferPairs,
   resolveAmbiguous,
   runReconciliation,
 } from './reconciliation';
@@ -51,6 +52,32 @@ const withdrawalActivity = (over: Partial<ActivityDetails> = {}): ActivityDetail
     comment: 'Bill Pay',
     fee: null,
     subtype: null,
+    ...over,
+  }) as ActivityDetails;
+
+const transferInActivity = (over: Partial<ActivityDetails> & { sourceGroupId?: string | null } = {}): ActivityDetails =>
+  ({
+    id: 'TIN-1',
+    accountId: 'WF-CARD',
+    activityType: 'TRANSFER_IN',
+    date: '2025-08-06T00:00:00+00:00',
+    amount: '50',
+    currency: 'USD',
+    comment: 'Old payment',
+    sourceGroupId: null,
+    ...over,
+  }) as ActivityDetails;
+
+const transferOutActivity = (over: Partial<ActivityDetails> & { sourceGroupId?: string | null } = {}): ActivityDetails =>
+  ({
+    id: 'TOUT-1',
+    accountId: 'WF-CASH',
+    activityType: 'TRANSFER_OUT',
+    date: '2025-08-05T00:00:00+00:00',
+    amount: '50',
+    currency: 'USD',
+    comment: 'Old withdrawal',
+    sourceGroupId: null,
     ...over,
   }) as ActivityDetails;
 
@@ -709,5 +736,131 @@ describe('resolveAmbiguous', () => {
     await expect(
       resolveAmbiguous(host.api, candidate({ inflowActivityId: 'CARD-ACT-1' }), ['WF-CASH'], 'GONE'),
     ).rejects.toThrow(/GONE/);
+  });
+});
+
+describe('relinkUnlinkedTransferPairs', () => {
+  it('relinks an unambiguous unlinked pair via saveMany, using the TRANSFER_IN id as sourceGroupId', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') return { data: [transferInActivity()], meta: { totalRowCount: 1 } };
+      if (filters.activityTypes === 'TRANSFER_OUT') return { data: [transferOutActivity()], meta: { totalRowCount: 1 } };
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
+
+    expect(result).toEqual({ relinked: 1, ambiguous: 0 });
+    expect(host.api.activities.saveMany).toHaveBeenCalledWith({
+      creates: [
+        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TIN-1' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TIN-1' }),
+      ],
+      deleteIds: ['TIN-1', 'TOUT-1'],
+    });
+  });
+
+  it('excludes a row that already has sourceGroupId set from matching entirely', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') {
+        return { data: [transferInActivity({ sourceGroupId: 'already-linked' })], meta: { totalRowCount: 1 } };
+      }
+      if (filters.activityTypes === 'TRANSFER_OUT') return { data: [transferOutActivity()], meta: { totalRowCount: 1 } };
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
+
+    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(host.api.activities.saveMany).not.toHaveBeenCalled();
+  });
+
+  it('leaves a TRANSFER_IN with zero withdrawal matches unlinked', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') return { data: [transferInActivity()], meta: { totalRowCount: 1 } };
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
+
+    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(host.api.activities.saveMany).not.toHaveBeenCalled();
+  });
+
+  it('counts ambiguous and does not call saveMany when 2+ matches exist for a row', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') return { data: [transferInActivity()], meta: { totalRowCount: 1 } };
+      if (filters.activityTypes === 'TRANSFER_OUT') {
+        return {
+          data: [transferOutActivity(), transferOutActivity({ id: 'TOUT-2', accountId: 'WF-CASH-2' })],
+          meta: { totalRowCount: 2 },
+        };
+      }
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH', 'WF-CASH-2']);
+
+    expect(result).toEqual({ relinked: 0, ambiguous: 1 });
+    expect(host.api.activities.saveMany).not.toHaveBeenCalled();
+  });
+
+  it("isolates a per-row failure so a later row still relinks", async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') {
+        return {
+          // TIN-GOOD/TOUT-GOOD use a distinct amount (75 vs the default 50)
+          // so they can't cross-match with the BAD pair — both TRANSFER_IN
+          // rows would otherwise share the same default amount/date and
+          // both TRANSFER_OUT rows the same default account, making every
+          // row match both counterparts (ambiguous) instead of the intended
+          // one clean success / one clean failure.
+          data: [transferInActivity({ id: 'TIN-BAD' }), transferInActivity({ id: 'TIN-GOOD', amount: '75' })],
+          meta: { totalRowCount: 2 },
+        };
+      }
+      if (filters.activityTypes === 'TRANSFER_OUT') {
+        return {
+          data: [transferOutActivity({ id: 'TOUT-BAD' }), transferOutActivity({ id: 'TOUT-GOOD', amount: '75' })],
+          meta: { totalRowCount: 2 },
+        };
+      }
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+    host.api.activities.saveMany = vi.fn(async (req: { deleteIds?: string[] }) => {
+      if (req.deleteIds?.includes('TIN-BAD')) {
+        return { created: [], updated: [], deleted: [], createdMappings: [], errors: [{ id: 'TIN-BAD', action: 'create', message: 'boom' }] };
+      }
+      return { created: [], updated: [], deleted: [], createdMappings: [], errors: [] };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
+
+    expect(result.relinked).toBe(1);
+    expect(host.api.logger.error).toHaveBeenCalledWith(expect.stringContaining('TIN-BAD'));
+  });
+
+  it('returns zero counts without searching when inflowAccountIds is empty', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn();
+
+    const result = await relinkUnlinkedTransferPairs(host.api, [], ['WF-CASH']);
+
+    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(host.api.activities.search).not.toHaveBeenCalled();
+  });
+
+  it('returns zero counts without searching when cashAccountIds is empty', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn();
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], []);
+
+    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(host.api.activities.search).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/sync/reconciliation.test.ts
+++ b/src/lib/sync/reconciliation.test.ts
@@ -35,6 +35,8 @@ const cardActivity = (over: Partial<ActivityDetails> = {}): ActivityDetails =>
     amount: '50',
     currency: 'USD',
     comment: 'Online Payment Thank You',
+    fee: null,
+    subtype: null,
     ...over,
   }) as ActivityDetails;
 
@@ -47,6 +49,8 @@ const withdrawalActivity = (over: Partial<ActivityDetails> = {}): ActivityDetail
     amount: '50',
     currency: 'USD',
     comment: 'Bill Pay',
+    fee: null,
+    subtype: null,
     ...over,
   }) as ActivityDetails;
 
@@ -65,8 +69,28 @@ describe('runReconciliation', () => {
     expect(summary.resolved).toBe(1);
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
       creates: [
-        expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-1' }),
-        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-1' }),
+        {
+          accountId: 'WF-CARD',
+          activityType: 'TRANSFER_IN',
+          activityDate: '2025-08-06T00:00:00+00:00',
+          amount: '50',
+          currency: 'USD',
+          comment: 'Online Payment Thank You',
+          fee: null,
+          subtype: null,
+          sourceGroupId: 'TXN-1',
+        },
+        {
+          accountId: 'WF-CASH',
+          activityType: 'TRANSFER_OUT',
+          activityDate: '2025-08-05T00:00:00+00:00',
+          amount: '50',
+          currency: 'USD',
+          comment: 'Bill Pay',
+          fee: null,
+          subtype: null,
+          sourceGroupId: 'TXN-1',
+        },
       ],
       deleteIds: ['CARD-ACT-1', 'CASH-ACT-1'],
     });
@@ -300,7 +324,7 @@ describe('runReconciliation', () => {
       updated: [],
       deleted: [],
       createdMappings: [],
-      errors: [{ id: 'CARD-ACT-1', action: 'update', message: 'row locked' }],
+      errors: [{ id: 'CARD-ACT-1', action: 'create', message: 'row locked' }],
     })) as never;
 
     const { candidates, summary } = await runReconciliation(host.api, [candidate()], ['WF-CASH'], NOW);

--- a/src/lib/sync/reconciliation.test.ts
+++ b/src/lib/sync/reconciliation.test.ts
@@ -750,7 +750,7 @@ describe('relinkUnlinkedTransferPairs', () => {
 
     const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
 
-    expect(result).toEqual({ relinked: 1, ambiguous: 0 });
+    expect(result).toEqual({ relinked: 1, unmatched: 0, ambiguous: 0, failed: 0 });
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
       creates: [
         expect.objectContaining({ accountId: 'WF-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TIN-1' }),
@@ -772,7 +772,7 @@ describe('relinkUnlinkedTransferPairs', () => {
 
     const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
 
-    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(result).toEqual({ relinked: 0, unmatched: 0, ambiguous: 0, failed: 0 });
     expect(host.api.activities.saveMany).not.toHaveBeenCalled();
   });
 
@@ -785,7 +785,7 @@ describe('relinkUnlinkedTransferPairs', () => {
 
     const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
 
-    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(result).toEqual({ relinked: 0, unmatched: 1, ambiguous: 0, failed: 0 });
     expect(host.api.activities.saveMany).not.toHaveBeenCalled();
   });
 
@@ -804,7 +804,7 @@ describe('relinkUnlinkedTransferPairs', () => {
 
     const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH', 'WF-CASH-2']);
 
-    expect(result).toEqual({ relinked: 0, ambiguous: 1 });
+    expect(result).toEqual({ relinked: 0, unmatched: 0, ambiguous: 1, failed: 0 });
     expect(host.api.activities.saveMany).not.toHaveBeenCalled();
   });
 
@@ -840,7 +840,7 @@ describe('relinkUnlinkedTransferPairs', () => {
 
     const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
 
-    expect(result.relinked).toBe(1);
+    expect(result).toEqual({ relinked: 1, unmatched: 0, ambiguous: 0, failed: 1 });
     expect(host.api.logger.error).toHaveBeenCalledWith(expect.stringContaining('TIN-BAD'));
   });
 
@@ -850,7 +850,7 @@ describe('relinkUnlinkedTransferPairs', () => {
 
     const result = await relinkUnlinkedTransferPairs(host.api, [], ['WF-CASH']);
 
-    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(result).toEqual({ relinked: 0, unmatched: 0, ambiguous: 0, failed: 0 });
     expect(host.api.activities.search).not.toHaveBeenCalled();
   });
 
@@ -860,7 +860,46 @@ describe('relinkUnlinkedTransferPairs', () => {
 
     const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], []);
 
-    expect(result).toEqual({ relinked: 0, ambiguous: 0 });
+    expect(result).toEqual({ relinked: 0, unmatched: 0, ambiguous: 0, failed: 0 });
     expect(host.api.activities.search).not.toHaveBeenCalled();
+  });
+
+  it('does not let a second TRANSFER_IN double-claim a TRANSFER_OUT already claimed this run', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') {
+        return {
+          data: [transferInActivity({ id: 'TIN-1' }), transferInActivity({ id: 'TIN-2' })],
+          meta: { totalRowCount: 2 },
+        };
+      }
+      if (filters.activityTypes === 'TRANSFER_OUT') {
+        // Only one real TRANSFER_OUT exists to match against both TRANSFER_IN rows.
+        return { data: [transferOutActivity()], meta: { totalRowCount: 1 } };
+      }
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
+
+    expect(result.relinked).toBe(1);
+    expect(host.api.activities.saveMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('excludes a TRANSFER_OUT row that already has sourceGroupId set from matching', async () => {
+    const host = createMockHost();
+    host.api.activities.search = vi.fn(async (_p: number, _s: number, filters: { activityTypes: string }) => {
+      if (filters.activityTypes === 'TRANSFER_IN') return { data: [transferInActivity()], meta: { totalRowCount: 1 } };
+      if (filters.activityTypes === 'TRANSFER_OUT') {
+        return { data: [transferOutActivity({ sourceGroupId: 'already-linked' })], meta: { totalRowCount: 1 } };
+      }
+      return { data: [], meta: { totalRowCount: 0 } };
+    }) as never;
+
+    const result = await relinkUnlinkedTransferPairs(host.api, ['WF-CARD'], ['WF-CASH']);
+
+    expect(result.relinked).toBe(0);
+    expect(result.unmatched).toBe(1);
+    expect(host.api.activities.saveMany).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/sync/reconciliation.ts
+++ b/src/lib/sync/reconciliation.ts
@@ -200,6 +200,9 @@ function toCreate(row: ActivityDetails, activityType: string, sourceGroupId: str
     currency: row.currency,
     comment: row.comment,
     fee: row.fee,
+    tax: row.tax,
+    fxRate: row.fxRate,
+    metadata: row.metadata,
     subtype: row.subtype,
     sourceGroupId,
   };
@@ -395,20 +398,30 @@ function sourceGroupIdOf(row: ActivityDetails): string | null {
 
 export interface RelinkSummary {
   relinked: number;
+  unmatched: number;
   ambiguous: number;
+  failed: number;
 }
 
 /**
- * Finds `TRANSFER_IN`/`TRANSFER_OUT` activities reclassified before
- * `sourceGroupId` linking existed (or by any other means that left them
- * unlinked) and relinks unambiguous 1:1 matches via `reclassifyPair`.
+ * Finds any `TRANSFER_IN`/`TRANSFER_OUT` activity in the mapped accounts
+ * that is missing `sourceGroupId` and relinks unambiguous 1:1 matches via
+ * `reclassifyPair`. This is deliberately provenance-agnostic: it doesn't
+ * matter whether a row was reclassified by this addon before `sourceGroupId`
+ * linking existed, entered manually, imported from a CSV, or created by
+ * another addon entirely — Wealthfolio's own Data Consistency checker
+ * doesn't care about provenance either, only about whether the link exists.
  *
- * Deliberately does not surface ambiguous matches for manual resolution the
- * way live candidates do — every existing pair here was created by a past
- * *unambiguous* match (that's the only way `reclassifyPair` is ever
- * called), so re-deriving that same match now should essentially never
- * produce ambiguity. `ambiguous` is counted so a caller can still report it,
- * but the pair is simply left alone rather than staged.
+ * Matching runs in passes: a row with 2+ candidates is set aside as
+ * ambiguous for the pass rather than staged, then retried in the next pass,
+ * since another row's successful claim can shrink its candidate pool down to
+ * exactly one. A row with zero matches is never retried — claiming a
+ * `TRANSFER_OUT` elsewhere can't conjure up a new match for a row that
+ * already had none. Passes stop once one makes no further progress, at which
+ * point any rows still ambiguous are counted and left alone rather than
+ * staged for manual resolution — the same reasoning as before: every
+ * existing pair was originally created by *some* unambiguous match, so
+ * lingering ambiguity here should be rare.
  */
 export async function relinkUnlinkedTransferPairs(
   api: HostAPI,
@@ -416,7 +429,7 @@ export async function relinkUnlinkedTransferPairs(
   cashAccountIds: string[],
 ): Promise<RelinkSummary> {
   if (inflowAccountIds.length === 0 || cashAccountIds.length === 0) {
-    return { relinked: 0, ambiguous: 0 };
+    return { relinked: 0, unmatched: 0, ambiguous: 0, failed: 0 };
   }
 
   const [transferIns, transferOuts] = await Promise.all([
@@ -426,32 +439,55 @@ export async function relinkUnlinkedTransferPairs(
   const unlinkedIns = transferIns.filter((r) => !sourceGroupIdOf(r));
   const unlinkedOuts = transferOuts.filter((r) => !sourceGroupIdOf(r));
 
+  api.logger.info(
+    `[simplefin] relink scan: ${unlinkedIns.length}/${transferIns.length} TRANSFER_IN unlinked, ${unlinkedOuts.length}/${transferOuts.length} TRANSFER_OUT unlinked`,
+  );
+
   let relinked = 0;
+  let unmatched = 0;
   let ambiguous = 0;
+  let failed = 0;
   const claimedOutIds = new Set<string>();
 
-  for (const inRow of unlinkedIns) {
-    const target: MatchTarget = {
-      inflowAccountId: inRow.accountId,
-      amount: inRow.amount ?? '0',
-      postedDate: toIsoDateOnly(inRow.date),
-    };
-    const matches = withdrawalMatches(unlinkedOuts, target).filter((o) => !claimedOutIds.has(o.id));
+  let pending = unlinkedIns;
+  for (;;) {
+    const stillAmbiguous: ActivityDetails[] = [];
+    let progressed = false;
 
-    if (matches.length === 0) continue;
-    if (matches.length > 1) {
-      ambiguous += 1;
-      continue;
+    for (const inRow of pending) {
+      const target: MatchTarget = {
+        inflowAccountId: inRow.accountId,
+        amount: inRow.amount ?? '0',
+        postedDate: toIsoDateOnly(inRow.date),
+      };
+      const matches = withdrawalMatches(unlinkedOuts, target).filter((o) => !claimedOutIds.has(o.id));
+
+      if (matches.length === 0) {
+        unmatched += 1;
+        continue;
+      }
+      if (matches.length > 1) {
+        stillAmbiguous.push(inRow);
+        continue;
+      }
+
+      try {
+        await reclassifyPair(api, inRow, matches[0], inRow.id);
+        claimedOutIds.add(matches[0].id);
+        relinked += 1;
+        progressed = true;
+      } catch (error) {
+        api.logger.error(`[simplefin] relink failed for TRANSFER_IN ${inRow.id}: ${String(error)}`);
+        failed += 1;
+      }
     }
 
-    try {
-      await reclassifyPair(api, inRow, matches[0], inRow.id);
-      claimedOutIds.add(matches[0].id);
-      relinked += 1;
-    } catch (error) {
-      api.logger.error(`[simplefin] relink failed for TRANSFER_IN ${inRow.id}: ${String(error)}`);
+    if (!progressed || stillAmbiguous.length === 0) {
+      ambiguous += stillAmbiguous.length;
+      break;
     }
+    pending = stillAmbiguous;
   }
 
-  return { relinked, ambiguous };
+  return { relinked, unmatched, ambiguous, failed };
 }

--- a/src/lib/sync/reconciliation.ts
+++ b/src/lib/sync/reconciliation.ts
@@ -152,6 +152,9 @@ async function findBackfillCandidatesOfType(
     .filter((row) => isPaymentCandidate(row.comment ?? '', keywords))
     .filter((row) => !isAlreadyStaged(row, existingStaging))
     .map((row) => ({
+      // Reused as `sourceGroupId` in `reclassifyPair`, which deletes the very
+      // activity `row.id` names here — that's fine, since a grouping key
+      // only needs to be unique and stable, not point at a surviving row.
       sfTransactionId: row.id,
       inflowAccountId: row.accountId,
       inflowActivityId: row.id,
@@ -186,9 +189,11 @@ function toCreate(row: ActivityDetails, activityType: string, sourceGroupId: str
     accountId: row.accountId,
     activityType,
     activityDate: row.date,
-    amount: row.amount,
+    amount: row.amount ?? '0',
     currency: row.currency,
     comment: row.comment,
+    fee: row.fee,
+    subtype: row.subtype,
     sourceGroupId,
   };
 }
@@ -218,6 +223,17 @@ function toCreate(row: ActivityDetails, activityType: string, sourceGroupId: str
  * `runReconciliation`) treats it the same as a hard failure, instead of
  * counting the candidate resolved while one or both legs never actually
  * changed.
+ *
+ * A single call is not the same as an atomic one, though. If the creates
+ * apply but the deletes don't, the original inflow activity is still sitting
+ * there as `CREDIT`/`DEPOSIT`, so the next reconciliation run will find it
+ * again and reclassify it a second time — producing a duplicate linked pair,
+ * unlike the old `update()` approach, which was naturally idempotent to
+ * retry. If the deletes apply but the creates don't, both original
+ * activities are gone with nothing written to replace them — unrecoverable
+ * data loss, not just a stuck pending candidate. Both failure modes are
+ * believed rare (a single host call either round-trips or it doesn't), but
+ * neither is actually solved by making it one request.
  */
 async function reclassifyPair(
   api: HostAPI,

--- a/src/lib/sync/reconciliation.ts
+++ b/src/lib/sync/reconciliation.ts
@@ -1,4 +1,4 @@
-import type { ActivityDetails, ActivityUpdate, HostAPI } from '@wealthfolio/addon-sdk';
+import type { ActivityCreate, ActivityDetails, HostAPI } from '@wealthfolio/addon-sdk';
 import type { InflowActivityType, StagedCandidate } from '../storage/staging';
 import { isPaymentCandidate } from './activities';
 import { normalise } from './balance';
@@ -181,29 +181,33 @@ export async function findBackfillCandidates(
   return [...cardCandidates, ...cashCandidates];
 }
 
-function toUpdate(row: ActivityDetails, activityType: string): ActivityUpdate {
+function toCreate(row: ActivityDetails, activityType: string, sourceGroupId: string): ActivityCreate {
   return {
-    id: row.id,
     accountId: row.accountId,
     activityType,
     activityDate: row.date,
     amount: row.amount,
     currency: row.currency,
     comment: row.comment,
+    sourceGroupId,
   };
 }
 
 /**
- * `sourceGroupId` is deliberately not set here — confirmed against a live
- * host that `activities.update()` doesn't persist it, so there is no
- * host-side visual pairing available; the two legs are linked only by the
- * staging record until it's dropped.
+ * Reclassifying via `activities.update()` was tried first (see the
+ * 2026-08-14 design doc) and confirmed against a live host to silently drop
+ * `sourceGroupId` — the two legs ended up correctly typed but never linked,
+ * which is invisible to `update()` but visible to Wealthfolio's own Data
+ * Consistency checker. A follow-up live-host probe (2026-08-26) confirmed
+ * `saveMany({ creates: [...] })` does persist it, so both legs are deleted
+ * and recreated instead of updated in place, linked by the candidate's own
+ * `sfTransactionId` as a shared `sourceGroupId`.
  *
- * Both legs are sent in a single `saveMany()` call rather than two
- * sequential `update()` calls: `findInflowActivity()` only ever searches
- * `candidate.inflowActivityType`, so if the inflow leg alone were
- * reclassified to `TRANSFER_IN` and the withdrawal leg's write then failed,
- * the next reconciliation attempt could never re-find the (now
+ * Both legs are still created/deleted in a single `saveMany()` call rather
+ * than sequential calls, for the same reason as before: `findInflowActivity()`
+ * only ever searches `candidate.inflowActivityType`, so if the inflow leg
+ * alone were recreated as `TRANSFER_IN` and the withdrawal leg's write then
+ * failed, the next reconciliation attempt could never re-find the (now
  * non-CREDIT/DEPOSIT) inflow activity — leaving the pair permanently
  * half-reclassified. One request, one failure path avoids that split-write
  * state.
@@ -222,7 +226,11 @@ async function reclassifyPair(
   sfTransactionId: string,
 ): Promise<void> {
   const result = await api.activities.saveMany({
-    updates: [toUpdate(inflowRow, 'TRANSFER_IN'), toUpdate(withdrawalRow, 'TRANSFER_OUT')],
+    creates: [
+      toCreate(inflowRow, 'TRANSFER_IN', sfTransactionId),
+      toCreate(withdrawalRow, 'TRANSFER_OUT', sfTransactionId),
+    ],
+    deleteIds: [inflowRow.id, withdrawalRow.id],
   });
   if (result.errors.length > 0) {
     throw new Error(

--- a/src/lib/sync/reconciliation.ts
+++ b/src/lib/sync/reconciliation.ts
@@ -77,12 +77,19 @@ export async function findInflowActivity(api: HostAPI, candidate: StagedCandidat
 }
 
 /**
- * Filters an already-fetched withdrawal pool down to this candidate's
- * matches (same amount, posted within the match window, in an account other
- * than the candidate's own inflow account). Pure and synchronous on purpose
- * — the withdrawal pool is identical for every candidate in a run, so
- * callers fetch it once via `searchAllByType` and reuse it across
- * candidates rather than re-fetching per candidate.
+ * The subset of a candidate's fields `withdrawalMatches` actually needs —
+ * lets a non-candidate caller (`relinkUnlinkedTransferPairs`) reuse the same
+ * matching logic without constructing a full `StagedCandidate`.
+ */
+type MatchTarget = Pick<StagedCandidate, 'inflowAccountId' | 'amount' | 'postedDate'>;
+
+/**
+ * Filters an already-fetched withdrawal pool down to this target's matches
+ * (same amount, posted within the match window, in an account other than
+ * the target's own inflow account). Pure and synchronous on purpose — the
+ * withdrawal pool is identical for every candidate in a run, so callers
+ * fetch it once via `searchAllByType` and reuse it across candidates rather
+ * than re-fetching per candidate.
  *
  * The same-account exclusion matters only for a cash-to-cash transfer
  * candidate — its own account is part of the withdrawal search pool, unlike
@@ -90,15 +97,15 @@ export async function findInflowActivity(api: HostAPI, candidate: StagedCandidat
  * excludes from that pool. Without it, a transfer's destination account
  * could match a withdrawal sitting in that very account.
  */
-function withdrawalMatches(withdrawals: ActivityDetails[], candidate: StagedCandidate): ActivityDetails[] {
-  const inflowPostedSeconds = Date.parse(candidate.postedDate) / 1000;
+function withdrawalMatches(withdrawals: ActivityDetails[], target: MatchTarget): ActivityDetails[] {
+  const inflowPostedSeconds = Date.parse(target.postedDate) / 1000;
   const windowStartSeconds = inflowPostedSeconds - MATCH_WINDOW_DAYS * SECONDS_PER_DAY;
 
   return withdrawals.filter((w) => {
-    if (w.accountId === candidate.inflowAccountId) return false;
+    if (w.accountId === target.inflowAccountId) return false;
     const postedSeconds = Date.parse(toIsoDateOnly(w.date)) / 1000;
     return (
-      normalise(w.amount ?? '0') === normalise(candidate.amount) &&
+      normalise(w.amount ?? '0') === normalise(target.amount) &&
       postedSeconds >= windowStartSeconds &&
       postedSeconds <= inflowPostedSeconds
     );
@@ -373,4 +380,78 @@ export async function resolveAmbiguous(
   }
 
   await reclassifyPair(api, inflowRow, withdrawalRow, candidate.sfTransactionId);
+}
+
+/**
+ * `sourceGroupId` is on the host's `Activity` model but missing from the
+ * SDK's `ActivityDetails` type — confirmed present in the runtime JSON
+ * regardless (2026-08-26 live probe, see the design doc). This cast is the
+ * one place that gap is bridged; every other read goes through this
+ * function.
+ */
+function sourceGroupIdOf(row: ActivityDetails): string | null {
+  return ((row as unknown as Record<string, unknown>).sourceGroupId as string | null | undefined) ?? null;
+}
+
+export interface RelinkSummary {
+  relinked: number;
+  ambiguous: number;
+}
+
+/**
+ * Finds `TRANSFER_IN`/`TRANSFER_OUT` activities reclassified before
+ * `sourceGroupId` linking existed (or by any other means that left them
+ * unlinked) and relinks unambiguous 1:1 matches via `reclassifyPair`.
+ *
+ * Deliberately does not surface ambiguous matches for manual resolution the
+ * way live candidates do — every existing pair here was created by a past
+ * *unambiguous* match (that's the only way `reclassifyPair` is ever
+ * called), so re-deriving that same match now should essentially never
+ * produce ambiguity. `ambiguous` is counted so a caller can still report it,
+ * but the pair is simply left alone rather than staged.
+ */
+export async function relinkUnlinkedTransferPairs(
+  api: HostAPI,
+  inflowAccountIds: string[],
+  cashAccountIds: string[],
+): Promise<RelinkSummary> {
+  if (inflowAccountIds.length === 0 || cashAccountIds.length === 0) {
+    return { relinked: 0, ambiguous: 0 };
+  }
+
+  const [transferIns, transferOuts] = await Promise.all([
+    searchAllByType(api, inflowAccountIds, 'TRANSFER_IN'),
+    searchAllByType(api, cashAccountIds, 'TRANSFER_OUT'),
+  ]);
+  const unlinkedIns = transferIns.filter((r) => !sourceGroupIdOf(r));
+  const unlinkedOuts = transferOuts.filter((r) => !sourceGroupIdOf(r));
+
+  let relinked = 0;
+  let ambiguous = 0;
+  const claimedOutIds = new Set<string>();
+
+  for (const inRow of unlinkedIns) {
+    const target: MatchTarget = {
+      inflowAccountId: inRow.accountId,
+      amount: inRow.amount ?? '0',
+      postedDate: toIsoDateOnly(inRow.date),
+    };
+    const matches = withdrawalMatches(unlinkedOuts, target).filter((o) => !claimedOutIds.has(o.id));
+
+    if (matches.length === 0) continue;
+    if (matches.length > 1) {
+      ambiguous += 1;
+      continue;
+    }
+
+    try {
+      await reclassifyPair(api, inRow, matches[0], inRow.id);
+      claimedOutIds.add(matches[0].id);
+      relinked += 1;
+    } catch (error) {
+      api.logger.error(`[simplefin] relink failed for TRANSFER_IN ${inRow.id}: ${String(error)}`);
+    }
+  }
+
+  return { relinked, ambiguous };
 }

--- a/src/lib/sync/run.test.ts
+++ b/src/lib/sync/run.test.ts
@@ -396,10 +396,11 @@ describe('runSync', () => {
     await runSync(host.api, cardConfig);
 
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
-      updates: [
-        expect.objectContaining({ id: 'CARD-ACT-1', activityType: 'TRANSFER_IN' }),
-        expect.objectContaining({ id: 'CASH-ACT-1', activityType: 'TRANSFER_OUT' }),
+      creates: [
+        expect.objectContaining({ accountId: 'ACT-CARD', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-PAY' }),
+        expect.objectContaining({ accountId: 'WF-CASH', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-PAY' }),
       ],
+      deleteIds: ['CARD-ACT-1', 'CASH-ACT-1'],
     });
     expect(await readStaging(host.api)).toEqual([]);
   });
@@ -492,10 +493,11 @@ describe('runSync', () => {
     await runSync(host.api, transferConfig);
 
     expect(host.api.activities.saveMany).toHaveBeenCalledWith({
-      updates: [
-        expect.objectContaining({ id: 'DEPOSIT-ACT-1', activityType: 'TRANSFER_IN' }),
-        expect.objectContaining({ id: 'CHECKING-WD-1', activityType: 'TRANSFER_OUT' }),
+      creates: [
+        expect.objectContaining({ accountId: 'WF-SAVINGS', activityType: 'TRANSFER_IN', sourceGroupId: 'TXN-XFER' }),
+        expect.objectContaining({ accountId: 'WF-CHECKING', activityType: 'TRANSFER_OUT', sourceGroupId: 'TXN-XFER' }),
       ],
+      deleteIds: ['DEPOSIT-ACT-1', 'CHECKING-WD-1'],
     });
     expect(await readStaging(host.api)).toEqual([]);
   });

--- a/src/lib/sync/run.test.ts
+++ b/src/lib/sync/run.test.ts
@@ -616,7 +616,7 @@ describe('runSync opening-balance backfill', () => {
     return { host, pushed };
   }
 
-  it('pushes a TRANSFER_IN opening-balance entry that closes the gap on first sync', async () => {
+  it('pushes a DEPOSIT opening-balance entry that closes the gap on first sync', async () => {
     const { host, pushed } = backfillHost('100.00', [
       { id: 'T1', posted: 1754438400, amount: '-10.00', description: 'X' },
     ]);
@@ -625,9 +625,21 @@ describe('runSync opening-balance backfill', () => {
 
     expect(pushed).toHaveLength(2);
     expect(pushed[0].activityType).toBe('WITHDRAWAL');
-    expect(pushed[1].activityType).toBe('TRANSFER_IN');
+    expect(pushed[1].activityType).toBe('DEPOSIT');
     expect(pushed[1].amount).toBe('110.00');
     expect(run.accounts[0].imported).toBe(2);
+  });
+
+  it('pushes a CREDIT instead of a DEPOSIT opening-balance entry on a credit-card account', async () => {
+    const { host, pushed } = backfillHost('100.00', [
+      { id: 'T1', posted: 1754438400, amount: '-10.00', description: 'X' },
+    ]);
+    host.api.accounts.getAll = vi.fn(async () => [{ id: 'WF-1', accountType: 'CREDIT_CARD', balance: 0 }] as never);
+
+    await runSync(host.api, backfillConfig);
+
+    expect(pushed).toHaveLength(2);
+    expect(pushed[1].activityType).toBe('CREDIT');
   });
 
   it('folds a pre-existing Wealthfolio balance into the plug instead of ignoring it', async () => {
@@ -650,7 +662,7 @@ describe('runSync opening-balance backfill', () => {
     await runSync(host.api, backfillConfig);
 
     expect(pushed).toHaveLength(2);
-    expect(pushed[1].activityType).toBe('TRANSFER_OUT');
+    expect(pushed[1].activityType).toBe('WITHDRAWAL');
     // sfBalance(100.00) - (preSync 500 + imported -10.00) = -390.00
     expect(pushed[1].amount).toBe('390.00');
   });

--- a/src/lib/sync/run.ts
+++ b/src/lib/sync/run.ts
@@ -51,7 +51,7 @@ async function fetchFullHistory(
 /**
  * Plugs the gap between SimpleFIN's current balance and whatever the
  * full-history pull actually landed in Wealthfolio, as one synthetic
- * TRANSFER_IN/OUT activity.
+ * DEPOSIT/WITHDRAWAL (or CREDIT on a credit-card account) activity.
  *
  * The post-import Wealthfolio balance is computed here, not read back from
  * the host: `portfolio.recalculate()` resolving is not a reliable signal
@@ -69,6 +69,7 @@ async function pushOpeningBalance(
   sfAccount: SfAccount,
   preSyncBalance: string | null,
   importedTxns: SfTransaction[],
+  destinationAccountType: AccountType,
 ): Promise<number> {
   const wfBalance = sumDecimal([preSyncBalance ?? '0', ...importedTxns.map((t) => t.amount)]);
 
@@ -84,6 +85,7 @@ async function pushOpeningBalance(
     },
     mapping,
     sfAccount.currency,
+    destinationAccountType,
   );
   if (!plug) return 0;
 
@@ -157,6 +159,7 @@ async function syncOne(
       ? ((await fetchFullHistory(api, baseUrl, mapping.sfAccountId)) ?? sfAccount)
       : sfAccount;
 
+    const destinationAccountType = wfAccountTypes.get(mapping.wfAccountId) ?? 'CASH';
     const {
       result,
       watermark: next,
@@ -167,7 +170,7 @@ async function syncOne(
       mapping,
       syncSfAccount,
       watermark,
-      wfAccountTypes.get(mapping.wfAccountId) ?? 'CASH',
+      destinationAccountType,
       paymentKeywords,
       transferKeywords,
     );
@@ -180,6 +183,7 @@ async function syncOne(
           syncSfAccount,
           wfBalances.get(mapping.wfAccountId) ?? null,
           importedTxns,
+          destinationAccountType,
         )
       : 0;
 

--- a/src/test/mockHost.ts
+++ b/src/test/mockHost.ts
@@ -42,10 +42,10 @@ export function createMockHost(): MockHost {
       import: vi.fn(),
       search: vi.fn(async () => ({ data: [], meta: { totalRowCount: 0 } })),
       update: vi.fn(async (activity: unknown) => activity),
-      saveMany: vi.fn(async (req: { updates?: unknown[] }) => ({
-        created: [],
+      saveMany: vi.fn(async (req: { creates?: unknown[]; updates?: unknown[]; deleteIds?: string[] }) => ({
+        created: (req.creates ?? []).map((c, i) => ({ id: `MOCK-CREATED-${i}`, ...(c as object) })),
         updated: req.updates ?? [],
-        deleted: [],
+        deleted: req.deleteIds ?? [],
         createdMappings: [],
         errors: [],
       })),


### PR DESCRIPTION
## Summary

- Wealthfolio's "Data Consistency" checker was flagging every transfer this addon reclassifies as an "incomplete transfer" (28 in production), even when both legs were correctly typed `TRANSFER_IN`/`TRANSFER_OUT` and matched exactly on amount/date/account.
- Root cause: `reclassifyPair()` reclassified both legs via `activities.update()`, which a live-host probe confirmed silently drops the `sourceGroupId` field Wealthfolio needs to recognize the pair as linked.
- Fix: `reclassifyPair()` now deletes both original activities and recreates them as `TRANSFER_IN`/`TRANSFER_OUT` with `sourceGroupId` set to the candidate's `sfTransactionId`, via a single `saveMany({ creates, deleteIds })` call — confirmed live against a `wealthfolio-e2e` host that this path does persist `sourceGroupId`, unlike `update()`. Also carries `fee`/`subtype`/`tax`/`fxRate`/`metadata` through on recreated activities (previously dropped since the old `update()` path never needed to specify them), and documents the delete+recreate failure-mode risk in the code comment.
- **Follow-up (#71):** the fix above only helps *future* reconciliations — the 28 pairs already reclassified under the old `update()` path have no staging record left to reprocess, and the existing backfill scanner only searches `CREDIT`/`DEPOSIT` activities (never revisits something already typed `TRANSFER_IN`/`TRANSFER_OUT`). Added `relinkUnlinkedTransferPairs()`: finds any `TRANSFER_IN`/`TRANSFER_OUT` activity in the mapped accounts missing `sourceGroupId` (regardless of what created it), matches unlinked pairs by amount/date/opposite-account using the same logic live candidates use, and relinks unambiguous 1:1 matches via the same `reclassifyPair()` — with a multi-pass retry so an earlier claim can unblock a later ambiguous row. Wired into the existing "Scan for older payments and transfers" button (never automatic), since delete+recreate on arbitrarily-old activities carries more risk than the few-day live-candidate window ever did.

Full investigation and design:
- `docs/superpowers/specs/2026-08-26-sourcegroupid-transfer-linking-design.md` / `docs/superpowers/plans/2026-08-26-sourcegroupid-transfer-linking.md`
- `docs/superpowers/specs/2026-08-26-backfill-relink-unlinked-transfers-design.md` / `docs/superpowers/plans/2026-08-26-backfill-relink-unlinked-transfers.md`

Closes #69
Closes #71

## Test plan
- [x] `pnpm test` — 212/212 passing
- [x] `pnpm type-check` — clean
- [x] Underlying host behavior (saveMany-creates persists sourceGroupId; update() doesn't) verified live against a `wealthfolio-e2e` container
- [ ] Live end-to-end "Sync now" / "Scan" click-through in `wealthfolio-e2e` — attempted but blocked by a browser-automation limitation (the addon's sandboxed iframe doesn't receive synthetic input in this environment); the fixed build is available for manual install/testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)