### PR TITLE
chore: prepare go-live — README, LICENSE, addon id rename

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Christian Mendieta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # simplefin-wealthfolio-addon
 
+[![Latest release](https://img.shields.io/github/v/release/christancho/simplefin-wealthfolio-addon)](https://github.com/christancho/simplefin-wealthfolio-addon/releases/latest)
+[![License: MIT](https://img.shields.io/github/license/christancho/simplefin-wealthfolio-addon)](LICENSE)
+
 Sync bank, credit-card and investment data from [SimpleFIN
 Bridge](https://bridge.simplefin.org) into [Wealthfolio](https://wealthfolio.app)
 — as a Wealthfolio **addon**, with no separate service to deploy.
-
-> **Status:** v1 in development. The skeleton builds and mounts; the sync
-> pipeline is being implemented against
-> [`docs/superpowers/plans/2026-08-07-simplefin-addon-v1.md`](docs/superpowers/plans/2026-08-07-simplefin-addon-v1.md).
 
 ---
 
@@ -59,10 +58,20 @@ rather not run another service.
 
 - **Wealthfolio 3.6.2+** (desktop or self-hosted) — the addon declares
   `minWealthfolioVersion: 3.6.2`
-- **Node.js 18+** and **pnpm**
 - A **SimpleFIN Bridge** account and a setup token
 
+## Installing
+
+1. Download the latest addon zip from the
+   [Releases page](https://github.com/christancho/simplefin-wealthfolio-addon/releases/latest).
+2. In Wealthfolio, go to **Settings → Addons → Install from file** and pick
+   the downloaded zip.
+3. Open the new **SimpleFIN Sync** page from the sidebar, paste your SimpleFIN
+   Bridge setup token, and map your accounts.
+
 ## Development
+
+Requires **Node.js 18+** and **pnpm**.
 
 ```bash
 pnpm install
@@ -130,4 +139,4 @@ include `Closes #N`.
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/manifest.json
+++ b/manifest.json
@@ -1,21 +1,22 @@
 {
-  "id": "simplefin-sync",
+  "id": "simplefin-wealthfolio-addon",
   "name": "SimpleFIN Sync",
   "version": "1.0.0",
   "description": "Sync bank, credit-card and investment data from SimpleFIN Bridge into Wealthfolio.",
-  "author": "christancho",
+  "author": "Christian Mendieta",
+  "homepage": "https://github.com/christancho/simplefin-wealthfolio-addon",
   "main": "dist/addon.js",
   "sdkVersion": "3.6.2",
   "minWealthfolioVersion": "3.6.2",
   "enabled": true,
   "repository": "https://github.com/christancho/simplefin-wealthfolio-addon",
   "contributes": {
-    "routes": [{ "id": "simplefin-sync" }],
+    "routes": [{ "id": "simplefin-wealthfolio-addon" }],
     "links": {
       "sidebar": [
         {
-          "id": "simplefin-sync",
-          "route": "simplefin-sync",
+          "id": "simplefin-wealthfolio-addon",
+          "route": "simplefin-wealthfolio-addon",
           "label": "SimpleFIN Sync",
           "icon": "plugs-connected",
           "order": 100

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "vite build --watch",
     "dev:server": "wealthfolio-addon dev",
     "clean": "rm -rf dist",
-    "package": "mkdir -p dist && find dist -name '*.map' -delete && zip -r dist/$npm_package_name-$npm_package_version.zip manifest.json dist/ assets/ README.md -x '*.map'",
+    "package": "mkdir -p dist && find dist -name '*.map' -delete && zip -r dist/$npm_package_name-$npm_package_version.zip manifest.json dist/ README.md -x '*.map'",
     "bundle": "pnpm clean && pnpm build && pnpm package",
     "lint": "tsc --noEmit",
     "type-check": "tsc --noEmit",

--- a/src/lib/__tests__/smoke.test.ts
+++ b/src/lib/__tests__/smoke.test.ts
@@ -3,6 +3,6 @@ import { ADDON_ID } from '../constants';
 
 describe('addon constants', () => {
   it('exposes the canonical addon id', () => {
-    expect(ADDON_ID).toBe('simplefin-sync');
+    expect(ADDON_ID).toBe('simplefin-wealthfolio-addon');
   });
 });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,5 @@
 /** Must match manifest `id`, `contributes.routes[].id`, and the route path segment. */
-export const ADDON_ID = 'simplefin-sync';
+export const ADDON_ID = 'simplefin-wealthfolio-addon';
 
 /** Storage/secret key prefix. Charset is constrained to [A-Za-z0-9_.:-] by the host. */
 export const KEY_PREFIX = 'simplefin';


### PR DESCRIPTION
## Summary
- Rewrite README.md for a public/end-user audience: drop the WIP status banner, add an Installing section, add release/license badges.
- Add MIT LICENSE file (already claimed by README/package.json/manifest.json but never actually present).
- Drop the unused `assets/` path from the `package` script — no assets dir exists, and it was throwing a `zip warning: name not matched` on every release.
- Rename the addon id from `simplefin-sync` to `simplefin-wealthfolio-addon` (manifest `id`, `contributes.routes[].id`, `contributes.links.sidebar[].id/route`, and `ADDON_ID` in `src/lib/constants.ts`) — the old id collides with an unrelated addon already published in the Wealthfolio community addon directory.
- Add `homepage` to manifest.json and use full author name.
- Repo visibility flipped to public, with description/topics/homepage set on GitHub.

## Test plan
- [x] `pnpm test` — 202 tests passing
- [x] `pnpm type-check` — clean
- [x] `pnpm bundle` — zip builds cleanly with no warnings