### PR TITLE
feat: add a stable download link to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ rather not run another service.
 
 ## Installing
 
-1. Download the latest addon zip from the
-   [Releases page](https://github.com/christancho/simplefin-wealthfolio-addon/releases/latest).
+1. **[Download the latest addon zip](https://github.com/christancho/simplefin-wealthfolio-addon/releases/latest/download/simplefin-wealthfolio-addon.zip)**
+   (always points to the newest release — see the
+   [Releases page](https://github.com/christancho/simplefin-wealthfolio-addon/releases/latest)
+   for changelogs and older versions).
 2. In Wealthfolio, go to **Settings → Addons → Install from file** and pick
    the downloaded zip.
 3. Open the new **SimpleFIN Sync** page from the sidebar, paste your SimpleFIN

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "vite build --watch",
     "dev:server": "wealthfolio-addon dev",
     "clean": "rm -rf dist",
-    "package": "mkdir -p dist && find dist -name '*.map' -delete && zip -r dist/$npm_package_name-$npm_package_version.zip manifest.json dist/ README.md -x '*.map'",
+    "package": "mkdir -p dist && find dist -name '*.map' -delete && zip -r dist/$npm_package_name.zip manifest.json dist/ README.md -x '*.map'",
     "bundle": "pnpm clean && pnpm build && pnpm package",
     "lint": "tsc --noEmit",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Drop the version from the release zip's filename (`simplefin-wealthfolio-addon-1.0.0.zip` → `simplefin-wealthfolio-addon.zip`) — the version is already tracked by the release tag itself.
- Link the README's Installing section directly at `.../releases/latest/download/simplefin-wealthfolio-addon.zip`, GitHub's stable "always the current release" URL, instead of the Releases page (kept as a secondary link for changelogs/older versions).

Using `feat:` deliberately — this also cuts a new release once merged through to `main`, which is what actually makes the new link resolve (the current v1.0.0 release still has the old versioned filename).

## Test plan
- [x] `pnpm test` — 215 passing
- [x] `pnpm bundle` locally — confirms the fixed-name zip builds cleanly, no self-inclusion issue
- [x] Verified the new download URL currently 404s against v1.0.0 (expected — will resolve once this ships a new release)