### PR TITLE
docs: restructure README, drop overstated manual-sync claim

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,38 @@
+# Development
+
+Requires **Node.js 18+** and **pnpm**.
+
+```bash
+pnpm install
+pnpm test          # Vitest unit tests
+pnpm type-check    # tsc --noEmit
+pnpm build         # -> dist/addon.js
+pnpm dev:server    # hot-reload dev server for a live Wealthfolio instance
+pnpm bundle        # clean + build + zip for distribution
+```
+
+To test against a real instance, run `pnpm dev:server` and load the addon into
+a self-hosted Wealthfolio via its addon developer settings.
+
+## Architecture notes
+
+Worth knowing before changing anything:
+
+- **Never call `createRoot`.** The host owns a single React root per addon and
+  mounts the route `component` itself. Calling `createRoot` leaves orphaned
+  trees whose re-renders never reach the DOM — the 3.6 "buttons do nothing"
+  bug. Register routes with `component:`, not `render:`.
+  *(The published `@wealthfolio/addon-sdk` README still shows the old
+  `createRoot` pattern. It is stale — follow the SDK's own type definitions.)*
+- **No react-router hooks.** The sandbox has no router provider; the host
+  passes the current location to the route component as a `location` prop.
+- **Host dependencies are never bundled.** React, react-dom, react-query,
+  `@wealthfolio/ui`, date-fns, lucide-react and recharts are provided by the
+  host, externalized in `vite.config.ts` and declared in `manifest.json`.
+- **Cash sync is stateful, and has to be.** `ActivityImport` carries no
+  `sourceSystem`/`sourceRecordId`, so Wealthfolio cannot dedupe our pushes.
+  The addon owns idempotency via a per-account watermark plus a bounded
+  recent-id window in `storage`. Holdings need none of this —
+  `snapshots.checkImport()` returns `existingDates`.
+- **`storage` has limits:** keys ≤128 chars from `[A-Za-z0-9_.:-]`, values
+  ~250 KB. Use many small keys. `localStorage` is unavailable in the sandbox.

--- a/README.md
+++ b/README.md
@@ -26,34 +26,6 @@ the addon `secrets` API; the SimpleFIN Bridge is reached through Wealthfolio's
 brokered network layer, so the access credentials are never embedded in a
 request the addon itself composes.
 
-## Manual sync only — and why
-
-This addon **cannot** sync automatically on a schedule. That is a hard
-constraint of the Wealthfolio addon runtime, not a design choice: addon code
-only executes while a Wealthfolio window is open with the addon mounted, and
-the SDK exposes no cron or background-job hook. "Sync every night
-automatically" is not implementable as an addon in any language.
-
-If you need unattended nightly sync, use the sibling project instead.
-
-### Relationship to `wf-simplefin`
-
-[`wf-simplefin`](https://github.com/christancho/wf-simplefin) solves the same
-problem as a standalone always-on Python service. The two are **independent
-products** — neither replaces the other:
-
-| | `wf-simplefin` | this project |
-|---|---|---|
-| Runs as | its own container/service | inside Wealthfolio |
-| Sync | automated, nightly, unattended | manual, user-triggered |
-| Deployment | a separate container to maintain | install the addon |
-| Integration | Wealthfolio REST API | addon `HostAPI` |
-
-Pick `wf-simplefin` if you want it to run without you. Pick this if you'd
-rather not run another service.
-
----
-
 ## Requirements
 
 - **Wealthfolio 3.6.2+** (desktop or self-hosted) — the addon declares
@@ -73,42 +45,7 @@ rather not run another service.
 
 ## Development
 
-Requires **Node.js 18+** and **pnpm**.
-
-```bash
-pnpm install
-pnpm test          # Vitest unit tests
-pnpm type-check    # tsc --noEmit
-pnpm build         # -> dist/addon.js
-pnpm dev:server    # hot-reload dev server for a live Wealthfolio instance
-pnpm bundle        # clean + build + zip for distribution
-```
-
-To test against a real instance, run `pnpm dev:server` and load the addon into
-a self-hosted Wealthfolio via its addon developer settings.
-
-### Architecture notes
-
-Worth knowing before changing anything:
-
-- **Never call `createRoot`.** The host owns a single React root per addon and
-  mounts the route `component` itself. Calling `createRoot` leaves orphaned
-  trees whose re-renders never reach the DOM — the 3.6 "buttons do nothing"
-  bug. Register routes with `component:`, not `render:`.
-  *(The published `@wealthfolio/addon-sdk` README still shows the old
-  `createRoot` pattern. It is stale — follow the SDK's own type definitions.)*
-- **No react-router hooks.** The sandbox has no router provider; the host
-  passes the current location to the route component as a `location` prop.
-- **Host dependencies are never bundled.** React, react-dom, react-query,
-  `@wealthfolio/ui`, date-fns, lucide-react and recharts are provided by the
-  host, externalized in `vite.config.ts` and declared in `manifest.json`.
-- **Cash sync is stateful, and has to be.** `ActivityImport` carries no
-  `sourceSystem`/`sourceRecordId`, so Wealthfolio cannot dedupe our pushes.
-  The addon owns idempotency via a per-account watermark plus a bounded
-  recent-id window in `storage`. Holdings need none of this —
-  `snapshots.checkImport()` returns `existingDates`.
-- **`storage` has limits:** keys ≤128 chars from `[A-Za-z0-9_.:-]`, values
-  ~250 KB. Use many small keys. `localStorage` is unavailable in the sandbox.
+See [DEVELOPMENT.md](DEVELOPMENT.md) for setup, commands, and architecture notes.
 
 ---
 
@@ -137,3 +74,21 @@ Work is tracked in GitHub Issues and the project board. In short: branch from
 ## License
 
 [MIT](LICENSE)
+
+---
+
+## Relationship to `wf-simplefin`
+
+[`wf-simplefin`](https://github.com/christancho/wf-simplefin) solves the same
+problem as a standalone always-on Python service. The two are **independent
+products** — neither replaces the other:
+
+| | `wf-simplefin` | this project |
+|---|---|---|
+| Runs as | its own container/service | inside Wealthfolio |
+| Sync | automated, nightly, unattended | manual, user-triggered |
+| Deployment | a separate container to maintain | install the addon |
+| Integration | Wealthfolio REST API | addon `HostAPI` |
+
+Pick `wf-simplefin` if you want it to run without you. Pick this if you'd
+rather not run another service.


### PR DESCRIPTION
## Summary
- Remove "Manual sync only — and why". Its "not implementable as an addon in any language" claim doesn't hold up against the SDK's own type docs (contributes.routes is a documented "lazy-activation surface" independent of addon code execution; enable() state persists for the addon sandbox's lifetime, not just while its route is mounted). Dropping rather than replacing with an unverified claim.
- Move "Relationship to wf-simplefin" to the bottom of the README as its own section.
- Extract Development + Architecture notes into a new DEVELOPMENT.md; README now links to it.

## Test plan
- [x] `pnpm test` — 215 passing
- [x] `pnpm type-check` — clean
- [x] Confirmed no remaining references to the removed section elsewhere in the repo