### PR TITLE
fix: drop synthetic opening-balance entry for credit-card accounts

### DIFF
--- a/src/lib/sync/openingBalance.test.ts
+++ b/src/lib/sync/openingBalance.test.ts
@@ -67,24 +67,14 @@ describe('buildOpeningBalanceActivity', () => {
     expect(activity?.amount).toBe('30.00');
   });
 
-  it('builds a CREDIT instead of a DEPOSIT on a credit-card account', () => {
+  it('returns null on a credit-card account even when the balances disagree', () => {
     const activity = buildOpeningBalanceActivity(
       { sfBalance: '100.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
       mapping,
       'USD',
       'CREDIT_CARD',
     );
-    expect(activity?.activityType).toBe('CREDIT');
-  });
-
-  it('still builds a WITHDRAWAL (not CREDIT) on a credit-card account when Wealthfolio holds more', () => {
-    const activity = buildOpeningBalanceActivity(
-      { sfBalance: '50.00', wfBalance: '80.00', earliestPosted: 1754438400, balanceDate: 1754524800 },
-      mapping,
-      'USD',
-      'CREDIT_CARD',
-    );
-    expect(activity?.activityType).toBe('WITHDRAWAL');
+    expect(activity).toBeNull();
   });
 
   it('dates the entry one day before the earliest posted transaction', () => {

--- a/src/lib/sync/openingBalance.ts
+++ b/src/lib/sync/openingBalance.ts
@@ -66,12 +66,16 @@ function isoDate(epochSeconds: number): string {
  * balance and whatever landed in Wealthfolio from the full-history backfill —
  * returns null when there is no gap.
  *
- * Imported as `DEPOSIT`/`WITHDRAWAL` (or `CREDIT` in place of `DEPOSIT` on a
- * credit-card account, mirroring `toActivityImport`), never `TRANSFER_IN`/
- * `TRANSFER_OUT` — this plug has no counterparty leg by construction (it's
- * money the account already had before this addon started tracking it, not a
- * transfer between two tracked accounts), so typing it as a transfer would
- * leave it permanently unlinkable and always flagged by Wealthfolio's Data
+ * Never built for a credit-card account: a card's balance self-zeros every
+ * statement cycle, so the plug would be a vendor-less charge with no lasting
+ * meaning, sitting in the first cycle's history and skewing that month's
+ * spend view. Real transactions are the only source of truth there.
+ *
+ * Imported as `DEPOSIT`/`WITHDRAWAL`, never `TRANSFER_IN`/`TRANSFER_OUT` —
+ * this plug has no counterparty leg by construction (it's money the account
+ * already had before this addon started tracking it, not a transfer between
+ * two tracked accounts), so typing it as a transfer would leave it
+ * permanently unlinkable and always flagged by Wealthfolio's Data
  * Consistency checker.
  */
 export function buildOpeningBalanceActivity(
@@ -80,6 +84,8 @@ export function buildOpeningBalanceActivity(
   currency: string,
   destinationAccountType: AccountType,
 ): ActivityImport | null {
+  if (destinationAccountType === 'CREDIT_CARD') return null;
+
   const remainder = subtractDecimal(input.sfBalance, input.wfBalance);
   if (/^0(\.0*)?$/.test(remainder)) return null;
 
@@ -87,11 +93,10 @@ export function buildOpeningBalanceActivity(
   const magnitude = remainder.replace(/^-/, '');
   const dateEpoch =
     input.earliestPosted !== null ? input.earliestPosted - SECONDS_PER_DAY : input.balanceDate;
-  const inflowType = destinationAccountType === 'CREDIT_CARD' ? 'CREDIT' : 'DEPOSIT';
 
   return {
     accountId: mapping.wfAccountId,
-    activityType: isOutflow ? 'WITHDRAWAL' : inflowType,
+    activityType: isOutflow ? 'WITHDRAWAL' : 'DEPOSIT',
     date: isoDate(dateEpoch),
     amount: magnitude,
     currency,

--- a/src/lib/sync/run.test.ts
+++ b/src/lib/sync/run.test.ts
@@ -630,7 +630,7 @@ describe('runSync opening-balance backfill', () => {
     expect(run.accounts[0].imported).toBe(2);
   });
 
-  it('pushes a CREDIT instead of a DEPOSIT opening-balance entry on a credit-card account', async () => {
+  it('pushes no opening-balance entry on a credit-card account, only the real transaction', async () => {
     const { host, pushed } = backfillHost('100.00', [
       { id: 'T1', posted: 1754438400, amount: '-10.00', description: 'X' },
     ]);
@@ -638,8 +638,8 @@ describe('runSync opening-balance backfill', () => {
 
     await runSync(host.api, backfillConfig);
 
-    expect(pushed).toHaveLength(2);
-    expect(pushed[1].activityType).toBe('CREDIT');
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0].activityType).toBe('WITHDRAWAL');
   });
 
   it('folds a pre-existing Wealthfolio balance into the plug instead of ignoring it', async () => {

--- a/src/lib/sync/run.ts
+++ b/src/lib/sync/run.ts
@@ -51,7 +51,8 @@ async function fetchFullHistory(
 /**
  * Plugs the gap between SimpleFIN's current balance and whatever the
  * full-history pull actually landed in Wealthfolio, as one synthetic
- * DEPOSIT/WITHDRAWAL (or CREDIT on a credit-card account) activity.
+ * DEPOSIT/WITHDRAWAL activity. No-op on a credit-card account — see
+ * `buildOpeningBalanceActivity`.
  *
  * The post-import Wealthfolio balance is computed here, not read back from
  * the host: `portfolio.recalculate()` resolving is not a reliable signal


### PR DESCRIPTION
## Summary
- Credit-card mappings no longer get a synthetic opening-balance activity on first sync — `buildOpeningBalanceActivity` now returns `null` unconditionally for `CREDIT_CARD` destinations, since a card's balance self-zeros every statement cycle and the plug fabricated a vendor-less charge with no lasting meaning.
- Cash/investment (`CASH`-mode, non-card) mappings are unaffected; the one-time backfill plug from #48/#61 still applies there.

Closes #83

## Test plan
- [x] `npx vitest run` — 214 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `openingBalance.test.ts`: credit-card mapping returns `null` regardless of balance gap
- [x] `run.test.ts`: a credit-card account's first sync pushes only the real transaction, no opening-balance entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdUganf283a6MkApWrBUXx