### PR TITLE
fix: register imported activities in the mapped Wealthfolio account's currency

### DIFF
--- a/src/lib/sync/activities.test.ts
+++ b/src/lib/sync/activities.test.ts
@@ -199,6 +199,7 @@ describe('syncCashAccount', () => {
       account([txn({ pending: true })]) as never,
       emptyWatermark(),
       'CASH',
+      'USD',
       [],
       [],
     );
@@ -216,6 +217,7 @@ describe('syncCashAccount', () => {
       account([txn()]) as never,
       { lastPosted: 1754438400, recentIds: ['TXN-1'] },
       'CASH',
+      'USD',
       [],
       [],
     );
@@ -239,7 +241,7 @@ describe('syncCashAccount', () => {
       };
     });
 
-    await syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', [], []);
+    await syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', 'USD', [], []);
     expect(order).toEqual(['check', 'import']);
   });
 
@@ -250,7 +252,7 @@ describe('syncCashAccount', () => {
     );
     host.api.activities.import = vi.fn();
 
-    const { result } = await syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', [], []);
+    const { result } = await syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', 'USD', [], []);
 
     expect(host.api.activities.import).not.toHaveBeenCalled();
     expect(result.duplicates).toBe(1);
@@ -263,7 +265,7 @@ describe('syncCashAccount', () => {
     );
     host.api.activities.import = vi.fn();
 
-    const { result } = await syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', [], []);
+    const { result } = await syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', 'USD', [], []);
 
     expect(host.api.activities.import).not.toHaveBeenCalled();
     expect(result.skipped).toBe(1);
@@ -278,10 +280,40 @@ describe('syncCashAccount', () => {
       summary: { total: 1, imported: 1, skipped: 0, duplicates: 0, assetsCreated: 0, success: true },
     }));
 
-    const { watermark } = await syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', [], []);
+    const { watermark } = await syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', 'USD', [], []);
 
     expect(watermark.lastPosted).toBe(1754438400);
     expect(watermark.recentIds).toContain('TXN-1');
+  });
+
+  it('registers activities in the mapped Wealthfolio account currency, not whatever the Bridge reports', async () => {
+    // Regression test: the Bridge's `sfAccount.currency` was being sent as-is,
+    // so a CAD Wealthfolio account mapped to a Bridge account reporting USD
+    // (or no currency at all) imported every transaction tagged USD.
+    const host = createMockHost();
+    host.api.activities.checkImport = vi.fn(async (a: ActivityImport[]) => a.map((row) => ({ ...row, isValid: true })));
+    let importedRows: ActivityImport[] = [];
+    host.api.activities.import = vi.fn(async (rows: ActivityImport[]) => {
+      importedRows = rows;
+      return {
+        activities: [],
+        importRunId: 'R1',
+        summary: { total: 1, imported: 1, skipped: 0, duplicates: 0, assetsCreated: 0, success: true },
+      };
+    });
+
+    await syncCashAccount(
+      host.api,
+      mapping,
+      account([txn()]) as never, // account().currency is 'USD'
+      emptyWatermark(),
+      'CASH',
+      'CAD',
+      [],
+      [],
+    );
+
+    expect(importedRows[0].currency).toBe('CAD');
   });
 
   it('fails the account when the host lands fewer rows than were submitted', async () => {
@@ -303,6 +335,7 @@ describe('syncCashAccount', () => {
         account([txn(), txn({ id: 'TXN-2', posted: 1754524800 })]) as never,
         emptyWatermark(),
         'CASH',
+        'USD',
         [],
         [],
       ),
@@ -319,7 +352,7 @@ describe('syncCashAccount', () => {
     }));
 
     await expect(
-      syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', [], []),
+      syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', 'USD', [], []),
     ).rejects.toThrow(/success=false/);
   });
 
@@ -336,7 +369,7 @@ describe('syncCashAccount', () => {
     }));
 
     const { watermark } = await syncCashAccount(
-      host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', [], [],
+      host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', 'USD', [], [],
     );
     expect(watermark.recentIds).toContain('TXN-1');
   });
@@ -349,7 +382,7 @@ describe('syncCashAccount', () => {
     });
 
     await expect(
-      syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', [], []),
+      syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', 'USD', [], []),
     ).rejects.toThrow(/host exploded/);
   });
 
@@ -360,7 +393,7 @@ describe('syncCashAccount', () => {
     });
 
     await expect(
-      syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', [], []),
+      syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', 'USD', [], []),
     ).rejects.toThrow(/Unprocessable Entity/);
 
     expect(host.api.logger.error).toHaveBeenCalledWith(expect.stringContaining(mapping.sfAccountName));
@@ -375,7 +408,7 @@ describe('syncCashAccount', () => {
     });
 
     await expect(
-      syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', [], []),
+      syncCashAccount(host.api, mapping, account([txn()]) as never, emptyWatermark(), 'CASH', 'USD', [], []),
     ).rejects.toThrow(/Unprocessable Entity/);
 
     expect(host.api.logger.error).toHaveBeenCalledWith(expect.stringContaining(mapping.sfAccountName));
@@ -401,6 +434,7 @@ describe('syncCashAccount', () => {
       account([txn({ amount: '50.00', payee: 'Card Payment' })]) as never,
       emptyWatermark(),
       'CREDIT_CARD',
+      'USD',
       [],
       [],
     );
@@ -423,6 +457,7 @@ describe('syncCashAccount', () => {
       account([txn({ amount: '75.00', payee: 'Online Payment Thank You' })]) as never,
       emptyWatermark(),
       'CREDIT_CARD',
+      'USD',
       ['PAYMENT'],
       [],
     );
@@ -447,6 +482,7 @@ describe('syncCashAccount', () => {
       account([txn({ amount: '75.00', payee: 'Amazon Refund' })]) as never,
       emptyWatermark(),
       'CREDIT_CARD',
+      'USD',
       ['PAYMENT'],
       [],
     );
@@ -458,6 +494,7 @@ describe('syncCashAccount', () => {
       account([txn({ amount: '-75.00', payee: 'Payment Center' })]) as never,
       emptyWatermark(),
       'CREDIT_CARD',
+      'USD',
       ['PAYMENT'],
       [],
     );
@@ -470,6 +507,7 @@ describe('syncCashAccount', () => {
       account([txn({ amount: '75.00', payee: 'Online Transfer From Checking' })]) as never,
       emptyWatermark(),
       'CREDIT_CARD',
+      'USD',
       ['PAYMENT'],
       ['TRANSFER'],
     );
@@ -491,6 +529,7 @@ describe('syncCashAccount', () => {
       account([txn({ amount: '200.00', payee: 'Online Transfer From Checking' })]) as never,
       emptyWatermark(),
       'CASH',
+      'USD',
       [],
       ['TRANSFER'],
     );
@@ -515,6 +554,7 @@ describe('syncCashAccount', () => {
       account([txn({ amount: '200.00', payee: 'Employer Payroll' })]) as never,
       emptyWatermark(),
       'CASH',
+      'USD',
       [],
       ['TRANSFER'],
     );
@@ -526,6 +566,7 @@ describe('syncCashAccount', () => {
       account([txn({ amount: '-200.00', payee: 'Online Transfer To Savings' })]) as never,
       emptyWatermark(),
       'CASH',
+      'USD',
       [],
       ['TRANSFER'],
     );
@@ -538,6 +579,7 @@ describe('syncCashAccount', () => {
       account([txn({ amount: '200.00', payee: 'Online Payment Thank You' })]) as never,
       emptyWatermark(),
       'CASH',
+      'USD',
       ['PAYMENT'],
       ['TRANSFER'],
     );

--- a/src/lib/sync/activities.ts
+++ b/src/lib/sync/activities.ts
@@ -146,6 +146,7 @@ export async function syncCashAccount(
   sfAccount: SfAccount,
   watermark: Watermark,
   accountType: AccountType,
+  currency: string,
   paymentKeywords: string[],
   transferKeywords: string[],
 ): Promise<{
@@ -167,7 +168,7 @@ export async function syncCashAccount(
     };
   }
 
-  const rows = candidates.map((t) => toActivityImport(t, mapping, sfAccount.currency, accountType));
+  const rows = candidates.map((t) => toActivityImport(t, mapping, currency, accountType));
   let checked;
   try {
     checked = await api.activities.checkImport(rows);
@@ -282,10 +283,10 @@ export async function syncCashAccount(
   const stagedCandidates =
     accountType === 'CREDIT_CARD'
       ? inflowTxns
-          .map((t) => detectCandidate(t, mapping, paymentKeywords, 'CREDIT', sfAccount.currency))
+          .map((t) => detectCandidate(t, mapping, paymentKeywords, 'CREDIT', currency))
           .filter((c): c is StagedCandidate => c !== null)
       : inflowTxns
-          .map((t) => detectCandidate(t, mapping, transferKeywords, 'DEPOSIT', sfAccount.currency))
+          .map((t) => detectCandidate(t, mapping, transferKeywords, 'DEPOSIT', currency))
           .filter((c): c is StagedCandidate => c !== null);
 
   return {

--- a/src/lib/sync/run.test.ts
+++ b/src/lib/sync/run.test.ts
@@ -110,6 +110,34 @@ describe('runSync', () => {
     expect(second?.imported).toBe(1);
   });
 
+  it('registers imported activities in the mapped Wealthfolio account currency, not the Bridge currency', async () => {
+    // Regression test: `bridgePayload` reports 'USD' for both accounts, but a
+    // Wealthfolio account is the source of truth for what currency it holds —
+    // this addon does no FX conversion, so pushing the Bridge's currency
+    // instead silently mislabeled every transaction.
+    const host = okHost();
+    await writeWatermark(host.api, 'WF-1', { lastPosted: 1754438400 - 86_400, recentIds: [] });
+    await writeWatermark(host.api, 'WF-2', { lastPosted: 1754438400 - 86_400, recentIds: [] });
+    host.api.accounts.getAll = vi.fn(async () => [
+      { id: 'WF-1', accountType: 'CASH', currency: 'CAD', balance: 0 },
+      { id: 'WF-2', accountType: 'CASH', currency: 'EUR', balance: 0 },
+    ] as never);
+    const importedRows: ActivityImport[] = [];
+    host.api.activities.import = vi.fn(async (rows: ActivityImport[]) => {
+      importedRows.push(...rows);
+      return {
+        activities: [],
+        importRunId: 'R',
+        summary: { total: rows.length, imported: rows.length, skipped: 0, duplicates: 0, assetsCreated: 0, success: true },
+      };
+    });
+
+    await runSync(host.api, config);
+
+    expect(importedRows.find((r) => r.accountId === 'WF-1')?.currency).toBe('CAD');
+    expect(importedRows.find((r) => r.accountId === 'WF-2')?.currency).toBe('EUR');
+  });
+
   it('records bridge errors without aborting the run', async () => {
     const host = createMockHost();
     host.respond(/\/accounts/, {

--- a/src/lib/sync/run.ts
+++ b/src/lib/sync/run.ts
@@ -71,6 +71,7 @@ async function pushOpeningBalance(
   preSyncBalance: string | null,
   importedTxns: SfTransaction[],
   destinationAccountType: AccountType,
+  currency: string,
 ): Promise<number> {
   const wfBalance = sumDecimal([preSyncBalance ?? '0', ...importedTxns.map((t) => t.amount)]);
 
@@ -90,7 +91,7 @@ async function pushOpeningBalance(
       balanceDate: sfAccount.balanceDate,
     },
     mapping,
-    sfAccount.currency,
+    currency,
     destinationAccountType,
   );
   if (!plug) return 0;
@@ -109,6 +110,7 @@ async function syncOne(
   sfAccount: SfAccount | undefined,
   wfBalances: Map<string, string>,
   wfAccountTypes: Map<string, AccountType>,
+  wfAccountCurrencies: Map<string, string>,
   paymentKeywords: string[],
   transferKeywords: string[],
 ): Promise<{ accountResult: AccountRunResult; candidates: StagedCandidate[] }> {
@@ -179,6 +181,12 @@ async function syncOne(
       : sfAccount;
 
     const destinationAccountType = wfAccountTypes.get(mapping.wfAccountId) ?? 'CASH';
+    // Activities register in the Wealthfolio account's own currency, not
+    // whatever the Bridge reports for the source account — this addon does no
+    // FX conversion, so the two must agree. Falls back to the Bridge's
+    // currency only if the account lookup above came back empty (e.g. the
+    // diagnostic `accounts.getAll()` read failed).
+    const destinationCurrency = wfAccountCurrencies.get(mapping.wfAccountId) ?? syncSfAccount.currency;
     const {
       result,
       watermark: next,
@@ -190,6 +198,7 @@ async function syncOne(
       syncSfAccount,
       watermark,
       destinationAccountType,
+      destinationCurrency,
       paymentKeywords,
       transferKeywords,
     );
@@ -203,6 +212,7 @@ async function syncOne(
           wfBalances.get(mapping.wfAccountId) ?? null,
           importedTxns,
           destinationAccountType,
+          destinationCurrency,
         )
       : 0;
 
@@ -278,9 +288,11 @@ export async function runSync(api: HostAPI, config: SyncConfig): Promise<SyncRun
   // a live host that `accounts.getAll()` doesn't carry a `balance` field at all.
   const wfBalances = new Map<string, string>();
   const wfAccountTypes = new Map<string, AccountType>();
+  const wfAccountCurrencies = new Map<string, string>();
   try {
     for (const account of await api.accounts.getAll()) {
       wfAccountTypes.set(account.id, account.accountType);
+      wfAccountCurrencies.set(account.id, account.currency);
     }
     await api.portfolio.recalculate();
     const valuations = await api.portfolio.getLatestValuations(
@@ -309,6 +321,7 @@ export async function runSync(api: HostAPI, config: SyncConfig): Promise<SyncRun
       bySfId.get(mapping.sfAccountId),
       wfBalances,
       wfAccountTypes,
+      wfAccountCurrencies,
       config.paymentKeywords,
       config.transferKeywords,
     );


### PR DESCRIPTION
## Summary
- `syncCashAccount` and the first-sync opening-balance plug always tagged pushed activities with `sfAccount.currency` (the SimpleFIN Bridge's reported currency for the source account) instead of the mapped Wealthfolio account's own currency — since this addon does no FX conversion, that silently mislabeled every transaction whenever the two disagreed (e.g. a CAD account importing as USD).
- `run.ts` now reads `account.currency` from `accounts.getAll()` alongside `accountType` and threads it through to `syncCashAccount` and the opening-balance plug, falling back to the Bridge's currency only if the account lookup itself failed.

Closes #96

## Test plan
- [x] `pnpm lint` (`tsc --noEmit`) passes
- [x] `pnpm test` — full suite (232 tests) passes, including two new regression tests asserting the Wealthfolio account currency wins over the Bridge's

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud9UVuZYJHa2JPSa7bfGtK